### PR TITLE
fix(build): enable legacy native library packaging for 16 KB page-size compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,6 +135,9 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+        jniLibs {
+            useLegacyPackaging = true
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR resolves the **16 KB page size alignment compatibility warning** on Android 15 (One UI 7 / Galaxy S25 & newer devices) by configuring `useLegacyPackaging = true` under `android.packaging.jniLibs` in `app/build.gradle.kts`.

---

## Background & Root Cause Analysis

### 1. 16 KB Page Alignment Compatibility Warning
- **Symptom**: On Android 15 devices with 16 KB kernel page support, installing/launching debug builds triggered an OS-level warning popup:
  > *"Android app compatibility: This app isn't 16 KB-compatible. ELF alignment check failed."*
  > Listing: `libffmpegJNI.so`, `libc++_shared.so`, `libandroidx.graphics.path.so`, `libdatastore_shared_counter.so`, etc.
- **Cause**: By default in modern AGP, native libraries (`.so`) are packaged uncompressed inside the APK so the OS attempts to `mmap` them directly from the APK file. When third-party pre-compiled dependencies (like Media3 FFmpeg, AndroidX Graphics Path, or NDK r26 `libc++_shared.so`) have 4 KB-aligned ELF LOAD segments or unaligned zip offsets, Android 15's compatibility checker flags them.
- **Fix**: Setting `jniLibs.useLegacyPackaging = true` forces Gradle to package libraries compressed and extract them to the app's native directory at install time with proper OS page boundary alignment, preventing the loader warning.

---

### 2. Context on Recent Wavy Seekbar Restoration (v3.3.1 -> Main)
- In the v3.3.1 release (`803e2e1`), the `SeekBar` composable in `PlayerHost.kt` was refactored to draw a custom capsule track directly, accidentally omitting the `if (wavyEnabled) WavySeekBar(...)` delegation. Additionally, `WavySeekBar.kt` had a missing `activeWidth` reference.
- Those issues were resolved in commit `906105d` (`fix(player): restore player controls styling and fix layout alignment`), which restored full `WavySeekBar` routing and controls layout on `main`.

---

## Changes

- **`app/build.gradle.kts`**:
  ```kotlin
  packaging {
      resources {
          excludes += "/META-INF/{AL2.0,LGPL2.1}"
      }
      jniLibs {
          useLegacyPackaging = true
      }
  }
  ```

---

## Verification & Testing

- Built `assembleRawRelease` & `assembleDebug` and tested on physical Android 15 hardware (`R5GYA0MP73T`).
- Verified zero OS-level compatibility warnings or ELF alignment dialogs on installation and launch.
- Verified Wavy Seekbar renders smoothly and animates in real-time during audio playback.