### PR TITLE
Fix next/previous doing nothing when playing from Downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,20 @@
   `app/src/main/java/com/lastwave/app/data/local/db/DownloadedTrackEntity.kt`,
   `app/src/main/java/com/lastwave/app/di/DatabaseModule.kt`,
   `app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt`
+
+### Fixed
+- **Skipping to the next track did nothing when playing from Downloads.**
+  `DownloadsViewModel.playTrack()` started playback via `MusicPlayer.play()`,
+  which always builds a single-track queue (`listOf(track)`) regardless of
+  how many tracks are downloaded. So the moment you played anything from the
+  Downloads screen, the player's queue had exactly one item — there was
+  never a "next" track to advance to, so `next()` correctly found no
+  following item and silently did nothing.
+
+  `playTrack()` now builds the full queue from every currently downloaded
+  track (in the same order shown on screen), starting at the tapped
+  track's position, via `MusicPlayer.playQueue()` instead of `play()`.
+  Next/previous now move through the rest of your downloads normally.
+
+  Files changed:
+  `app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt`

--- a/app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt
+++ b/app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt
@@ -125,21 +125,25 @@ class DownloadsViewModel @Inject constructor(
     }
 
     fun playTrack(track: DownloadedTrackEntity) {
-        val playable = PlayableTrack(
-            title = track.title,
-            artist = track.artist,
-            album = track.album,
-            artworkUrl = track.artworkUrl,
-            playbackUrl = track.mediaStoreUri ?: track.filePath,
-        )
+        val allTracks = downloadedTracks.value
+        val startIndex = allTracks.indexOfFirst { it.id == track.id }.let { if (it >= 0) it else 0 }
+        val queue = (allTracks.ifEmpty { listOf(track) }).map { it.toPlayableTrack() }
         try {
-            musicPlayer.play(playable, sourceLabel = "Downloads")
+            musicPlayer.playQueue(queue, startIndex = startIndex, sourceLabel = "Downloads")
         } catch (error: Exception) {
             android.util.Log.e("DownloadsViewModel", "Could not play download", error)
         } catch (error: LinkageError) {
             android.util.Log.e("DownloadsViewModel", "Playback unsupported on this device", error)
         }
     }
+
+    private fun DownloadedTrackEntity.toPlayableTrack(): PlayableTrack = PlayableTrack(
+        title = title,
+        artist = artist,
+        album = album,
+        artworkUrl = artworkUrl,
+        playbackUrl = mediaStoreUri ?: filePath,
+    )
 
     fun openInFileManager() {
         try {


### PR DESCRIPTION
DownloadsViewModel.playTrack() always started playback with a single-track queue, so there was never a next track to advance to. It now builds the queue from all downloaded tracks and starts at the tapped track's position.