### PR TITLE
Fix duplicate media notification on Android 10 (One UI 2.x)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@
 # Copy this file to .env or local.properties for local builds
 # ==========================================
 
-QOBUZ_BACKEND_URL=https://your-backend-domain.com
-QOBUZ_API_KEY=your_qobuz_api_key_here
+LOSSLESS_BACKEND_URL=https://your-lossless-backend-domain.com
+LOSSLESS_API_KEY=your_lossless_api_key_here
 LYRICS_API_KEY=your_lyrics_secret_token_here
 
 # Release Keystore Signing Credentials (Local builds)
@@ -14,6 +14,9 @@ RELEASE_KEY_ALIAS=release_key
 RELEASE_KEY_PASSWORD=your_key_password_here
 
 # GitHub Actions Secrets (Set in Repo Settings -> Secrets):
+# LOSSLESS_BACKEND_URL=<your-lossless-backend-url>
+# LOSSLESS_API_KEY=<your-lossless-api-key>
+# LYRICS_API_KEY=<your-lyrics-api-key>
 # SIGNING_KEY=<base64-encoded-keystore-string>
 # KEY_STORE_PASSWORD=<your-keystore-password>
 # ALIAS=release_key

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -34,8 +34,8 @@ jobs:
 
       - name: Build Beta Release APKs
         env:
-          QOBUZ_BACKEND_URL: ${{ secrets.QOBUZ_BACKEND_URL }}
-          QOBUZ_API_KEY: ${{ secrets.QOBUZ_API_KEY }}
+          LOSSLESS_BACKEND_URL: ${{ secrets.LOSSLESS_BACKEND_URL }}
+          LOSSLESS_API_KEY: ${{ secrets.LOSSLESS_API_KEY }}
           LYRICS_API_KEY: ${{ secrets.LYRICS_API_KEY }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           RELEASE_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD || secrets.RELEASE_STORE_PASSWORD }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -36,6 +36,8 @@ jobs:
         env:
           LOSSLESS_BACKEND_URL: ${{ secrets.LOSSLESS_BACKEND_URL }}
           LOSSLESS_API_KEY: ${{ secrets.LOSSLESS_API_KEY }}
+          QOBUZ_BACKEND_URL: ${{ secrets.QOBUZ_BACKEND_URL }}
+          QOBUZ_API_KEY: ${{ secrets.QOBUZ_API_KEY }}
           LYRICS_API_KEY: ${{ secrets.LYRICS_API_KEY }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           RELEASE_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD || secrets.RELEASE_STORE_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           LOSSLESS_BACKEND_URL: ${{ secrets.LOSSLESS_BACKEND_URL }}
           LOSSLESS_API_KEY: ${{ secrets.LOSSLESS_API_KEY }}
+          QOBUZ_BACKEND_URL: ${{ secrets.QOBUZ_BACKEND_URL }}
+          QOBUZ_API_KEY: ${{ secrets.QOBUZ_API_KEY }}
           LYRICS_API_KEY: ${{ secrets.LYRICS_API_KEY }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           RELEASE_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD || secrets.RELEASE_STORE_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Build Release APKs (compressed + raw)
         env:
-          QOBUZ_BACKEND_URL: ${{ secrets.QOBUZ_BACKEND_URL }}
-          QOBUZ_API_KEY: ${{ secrets.QOBUZ_API_KEY }}
+          LOSSLESS_BACKEND_URL: ${{ secrets.LOSSLESS_BACKEND_URL }}
+          LOSSLESS_API_KEY: ${{ secrets.LOSSLESS_API_KEY }}
           LYRICS_API_KEY: ${{ secrets.LYRICS_API_KEY }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           RELEASE_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD || secrets.RELEASE_STORE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
         env:
           LOSSLESS_BACKEND_URL: ${{ secrets.LOSSLESS_BACKEND_URL }}
           LOSSLESS_API_KEY: ${{ secrets.LOSSLESS_API_KEY }}
+          QOBUZ_BACKEND_URL: ${{ secrets.QOBUZ_BACKEND_URL }}
+          QOBUZ_API_KEY: ${{ secrets.QOBUZ_API_KEY }}
           LYRICS_API_KEY: ${{ secrets.LYRICS_API_KEY }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           RELEASE_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD || secrets.RELEASE_STORE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Build Release APKs (compressed + raw)
         env:
-          QOBUZ_BACKEND_URL: ${{ secrets.QOBUZ_BACKEND_URL }}
-          QOBUZ_API_KEY: ${{ secrets.QOBUZ_API_KEY }}
+          LOSSLESS_BACKEND_URL: ${{ secrets.LOSSLESS_BACKEND_URL }}
+          LOSSLESS_API_KEY: ${{ secrets.LOSSLESS_API_KEY }}
           LYRICS_API_KEY: ${{ secrets.LYRICS_API_KEY }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           RELEASE_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD || secrets.RELEASE_STORE_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,34 +22,6 @@
   Files changed:
   `app/src/main/java/com/lastwave/app/playback/MusicPlaybackService.kt`
 
-### Added
-- **"Continue as guest" option on the login screen.**
-  Login was previously required before reaching the main app at all —
-  `Screen.Splash` routed straight to `Screen.Login` whenever `AuthState`
-  was `SignedOut`, with no way past it. Playback itself never depended on
-  being signed in (`MusicPlayer`/`LinkPlaybackResolver` don't reference
-  `AuthState`), so this was a navigation gate, not a playback requirement.
-
-  Added a guest path that skips Last.fm sign-in entirely, with no network
-  call:
-  - `SessionPreferences.continueAsGuest()` sets the session username to
-    the existing `"Guest User"` sentinel that `HomeRepository`,
-    `GenerateRepository`, and `TasteProfileProvider` already check for to
-    skip personalized/authenticated Last.fm calls — so those features
-    degrade gracefully instead of erroring with no session.
-  - `AuthRepository.continueAsGuest()` / `AuthViewModel.continueAsGuest()`
-    wire it through to the UI.
-  - `LoginScreen` gets a new "Continue as guest" button; existing
-    sign-in-success navigation (on `AuthState.SignedIn`) picks it up
-    automatically since guest mode resolves to that same state.
-
-  Files changed:
-  `app/src/main/java/com/lastwave/app/data/local/SessionPreferences.kt`,
-  `app/src/main/java/com/lastwave/app/data/repository/AuthRepository.kt`,
-  `app/src/main/java/com/lastwave/app/ui/auth/AuthViewModel.kt`,
-  `app/src/main/java/com/lastwave/app/ui/auth/LoginScreen.kt`,
-  `app/src/main/java/com/lastwave/app/ui/navigation/NavGraph.kt`
-
 ## 2026-09-02 — musaibbhat120605
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,21 @@
 
   Files changed:
   `app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt`
+### Improved
+***Download speed.
+Removed a duplicate network call: downloadTrack() looked up
+innerTube.findBestMatch() once for artwork/album backfill, then called
+it again later for the YouTube fallback stream lookup. The result is
+now cached and reused, so this search only ever runs once per track.
+Qobuz stream resolution now runs concurrently with artwork/metadata
+resolution (coroutineScope + async) instead of waiting for them to
+finish first — the two are independent, so their network round-trips
+now overlap instead of stacking up serially (previously up to ~7.5s of
+pure latency per track before the transfer even started).
+Added a concurrency cap (MAX_CONCURRENT_DOWNLOADS = 3) via a
+Semaphore around each track's full download pipeline, matching the
+pattern already used by the Nocturne project. Uncapped concurrent
+downloads (e.g. downloading a whole playlist) were firing every track's
+network calls simultaneously, competing for the same CDN/API and
+risking throttling — working against overall speed rather than for it.
+Files changed: app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,21 +92,3 @@
 
   Files changed:
   `app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt`
-### Improved
-***Download speed.
-Removed a duplicate network call: downloadTrack() looked up
-innerTube.findBestMatch() once for artwork/album backfill, then called
-it again later for the YouTube fallback stream lookup. The result is
-now cached and reused, so this search only ever runs once per track.
-Qobuz stream resolution now runs concurrently with artwork/metadata
-resolution (coroutineScope + async) instead of waiting for them to
-finish first — the two are independent, so their network round-trips
-now overlap instead of stacking up serially (previously up to ~7.5s of
-pure latency per track before the transfer even started).
-Added a concurrency cap (MAX_CONCURRENT_DOWNLOADS = 3) via a
-Semaphore around each track's full download pipeline, matching the
-pattern already used by the Nocturne project. Uncapped concurrent
-downloads (e.g. downloading a whole playlist) were firing every track's
-network calls simultaneously, competing for the same CDN/API and
-risking throttling — working against overall speed rather than for it.
-Files changed: app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Duplicate/overlapping "now playing" notification on Android 10 (One UI 2.x).**
+  `buildNotification()` used `Notification.DecoratedMediaCustomViewStyle`
+  with a `MediaSession` attached, alongside a fully custom `RemoteViews`
+  player (own artwork, title, artist, transport buttons). On Android 10 +
+  Samsung One UI 2.x, SystemUI's older media-notification renderer drew
+  its own full media chrome as a second layer instead of just framing the
+  custom view, producing two overlapping players in the notification
+  shade/quick controls.
+
+  Now version-gated: Android 11+ keeps `DecoratedMediaCustomViewStyle`
+  with the session attached as before; Android 10 and below uses
+  `Notification.DecoratedCustomViewStyle` (no session tag on the
+  notification itself). Lock screen controls, Bluetooth, Android Auto,
+  and the in-app widget are unaffected, since they all read from
+  `mediaSession` directly rather than this notification's `Style` object.
+
+  Files changed:
+  `app/src/main/java/com/lastwave/app/playback/MusicPlaybackService.kt`
+
+### Added
+- **"Continue as guest" option on the login screen.**
+  Login was previously required before reaching the main app at all —
+  `Screen.Splash` routed straight to `Screen.Login` whenever `AuthState`
+  was `SignedOut`, with no way past it. Playback itself never depended on
+  being signed in (`MusicPlayer`/`LinkPlaybackResolver` don't reference
+  `AuthState`), so this was a navigation gate, not a playback requirement.
+
+  Added a guest path that skips Last.fm sign-in entirely, with no network
+  call:
+  - `SessionPreferences.continueAsGuest()` sets the session username to
+    the existing `"Guest User"` sentinel that `HomeRepository`,
+    `GenerateRepository`, and `TasteProfileProvider` already check for to
+    skip personalized/authenticated Last.fm calls — so those features
+    degrade gracefully instead of erroring with no session.
+  - `AuthRepository.continueAsGuest()` / `AuthViewModel.continueAsGuest()`
+    wire it through to the UI.
+  - `LoginScreen` gets a new "Continue as guest" button; existing
+    sign-in-success navigation (on `AuthState.SignedIn`) picks it up
+    automatically since guest mode resolves to that same state.
+
+  Files changed:
+  `app/src/main/java/com/lastwave/app/data/local/SessionPreferences.kt`,
+  `app/src/main/java/com/lastwave/app/data/repository/AuthRepository.kt`,
+  `app/src/main/java/com/lastwave/app/ui/auth/AuthViewModel.kt`,
+  `app/src/main/java/com/lastwave/app/ui/auth/LoginScreen.kt`,
+  `app/src/main/java/com/lastwave/app/ui/navigation/NavGraph.kt`
+
 ## 2026-09-02 — musaibbhat120605
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,20 @@
   `app/src/main/java/com/lastwave/app/data/local/db/DownloadedTrackEntity.kt`,
   `app/src/main/java/com/lastwave/app/di/DatabaseModule.kt`,
   `app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt`
+
+### Fixed
+- **Skipping to the next track did nothing when playing from Downloads.**
+  `DownloadsViewModel.playTrack()` started playback via `MusicPlayer.play()`,
+  which always builds a single-track queue (`listOf(track)`) regardless of
+  how many tracks are downloaded. So the moment you played anything from the
+  Downloads screen, the player's queue had exactly one item — there was
+  never a "next" track to advance to, so `next()` correctly found no
+  following item and silently did nothing.
+
+  `playTrack()` now builds the full queue from every currently downloaded
+  track (in the same order shown on screen), starting at the tapped
+  track's position, via `MusicPlayer.playQueue()` instead of `play()`.
+  Next/previous now move through the rest of your downloads normally.
+
+  Files changed:
+  `app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt`

--- a/README.md
+++ b/README.md
@@ -2,34 +2,31 @@
 
 <img src="lastwave_logo.png" alt="LastWave Logo" width="120" height="120" style="border-radius: 50%;" />
 
-# LastWave v3.4.1
+# LastWave
 
-**High-Resolution Lossless Music Streaming & Player with Real-Time Synced Lyrics & Smart Discovery for Android, built with Material 3 Expressive design.**
+### High-Resolution Lossless Audio Streaming & Native Music Player for Android
 
 <p align="center">
-  <a href="https://github.com/duxtami/LastWave-native/stargazers">
-    <img src="https://img.shields.io/github/stars/duxtami/LastWave-native?style=for-the-badge&color=ffd0b0&labelColor=2d2d2d" alt="Stars" />
-  </a>
-  <a href="https://github.com/duxtami/LastWave-native/network/members">
-    <img src="https://img.shields.io/github/forks/duxtami/LastWave-native?style=for-the-badge&color=ffb4a2&labelColor=2d2d2d" alt="Forks" />
+  <a href="https://github.com/Clash-Projects/LastWave-native/releases">
+    <img src="https://img.shields.io/badge/Platform-Android_8.0+-3DDC84?style=for-the-badge&logo=android&logoColor=white&labelColor=1a1a1a" alt="Platform" />
   </a>
   <a href="#">
-    <img src="https://img.shields.io/badge/Audio-Hi--Res%20Lossless%20FLAC-00E5FF?style=for-the-badge&logo=flac&logoColor=white&labelColor=012226" alt="Hi-Res Lossless FLAC" />
+    <img src="https://img.shields.io/badge/Audio-24--bit_%2F_192kHz_FLAC-00E5FF?style=for-the-badge&logo=flac&logoColor=white&labelColor=1a1a1a" alt="Hi-Res Lossless FLAC" />
   </a>
   <a href="#">
-    <img src="https://img.shields.io/badge/Version-3.4.1--native-C6F100?style=for-the-badge&labelColor=012226" alt="Version 3.4.1-native" />
+    <img src="https://img.shields.io/badge/Language-Kotlin_%26_C++-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white&labelColor=1a1a1a" alt="Kotlin & C++" />
   </a>
   <a href="#">
-    <img src="https://img.shields.io/badge/Platform-Android-3DDC84?style=for-the-badge&logo=android&logoColor=white&labelColor=2d2d2d" alt="Platform" />
+    <img src="https://img.shields.io/badge/UI-Material_3_Expressive-C6F100?style=for-the-badge&labelColor=1a1a1a" alt="Material 3 Expressive" />
   </a>
 </p>
 
 <p align="center">
   <a href="https://t.me/clashprojects">
-    <img src="https://img.shields.io/badge/Telegram-Updates%20%26%20Support-24A1DE?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram Support" />
+    <img src="https://img.shields.io/badge/Telegram-Join_Community-24A1DE?style=flat-square&logo=telegram&logoColor=white" alt="Telegram Community" />
   </a>
-  <a href="https://t.me/MaterialYouApp">
-    <img src="https://img.shields.io/badge/Telegram-More%20From%20Us-0088cc?style=for-the-badge&logo=telegram&logoColor=white" alt="More From Us" />
+  <a href="https://github.com/Clash-Projects/LastWave-native/releases">
+    <img src="https://img.shields.io/badge/Release-v3.4.1--native-blue?style=flat-square" alt="Latest Release" />
   </a>
 </p>
 
@@ -50,77 +47,65 @@
 
 <br/>
 
-## <img src="https://api.iconify.design/lucide:sparkles.svg?color=%23C6F100" width="20" height="20" align="center" /> Overview
+## Overview
 
-**LastWave** is a native Android music streaming app engineered for audiophiles and music lovers. It delivers studio-quality **Hi-Res Lossless FLAC (up to 24-bit/192kHz)** and Opus playback, offline downloads with full embedded metadata, kinetic real-time synchronized lyrics, smart algorithmic playlist generation, and automatic scrobbling across all your devices.
+**LastWave** is an advanced native Android music streaming and playback application crafted for audiophiles and high-fidelity audio enthusiasts. Built from the ground up with **Kotlin** and a **Custom Native C++ Audio Pipeline**, LastWave delivers uncompressed, bit-perfect **24-bit / 192kHz Studio Master FLAC** reproduction alongside intelligent recommendations, synchronized kinetic typography, and persistent background scrobbling.
 
-Designed from the ground up around **Material 3 Expressive**, LastWave pairs an ultra-smooth visual experience with uncompromising audio fidelity.
-
----
-
-## <img src="https://api.iconify.design/lucide:headphones.svg?color=%23C6F100" width="20" height="20" align="center" /> Lossless Audio Streaming & Backend
-
-LastWave features a lossless streaming and download engine powered directly by the **[clashflac](https://github.com/ajisth69/clashflac)** backend:
-
-- <img src="https://api.iconify.design/lucide:disc.svg?color=%2300E5FF" width="16" height="16" align="center" /> **Studio Master Quality:** Stream and download bit-perfect FLAC audio up to **24-bit / 192kHz** directly from Qobuz via **[clashflac](https://github.com/ajisth69/clashflac)**.
-- <img src="https://api.iconify.design/lucide:zap.svg?color=%23C6F100" width="16" height="16" align="center" /> **Opus & High-Efficiency Audio:** Seamless dual-engine fallback streaming via YouTube Music Opus for exhaustive global catalog coverage.
-- <img src="https://api.iconify.design/lucide:download.svg?color=%23C6F100" width="16" height="16" align="center" /> **Full-Fidelity Offline Downloads:** One-tap downloads saved directly to your local storage (`Music/LastWave`), fully tagged with high-res cover art, release tags, and synchronized LRCLIB `.lrc` lyrics.
-- <img src="https://api.iconify.design/lucide:sliders.svg?color=%23C6F100" width="16" height="16" align="center" /> **Zero-Gap Playback:** Powered by AndroidX Media3 ExoPlayer with foreground audio playback and lockscreen media session controls.
+The interface is architected according to Google's latest **Material 3 Expressive** design system, combining fluid morphing transitions, dynamic HSL tonal palettes, and tactile haptic feedback.
 
 ---
 
-## <img src="https://api.iconify.design/lucide:layers.svg?color=%23C6F100" width="20" height="20" align="center" /> Key Features
+## Technical Specifications & Architecture
 
-| Icon | Feature | Highlight |
-|:---:|:---|:---|
-| <img src="https://api.iconify.design/lucide:music.svg?color=%2300E5FF" width="20" height="20" /> | **Lossless Streaming** | True Hi-Res 24-bit FLAC & Opus streaming with lossless bitstream output. |
-| <img src="https://api.iconify.design/lucide:arrow-down-to-line.svg?color=%23C6F100" width="20" height="20" /> | **Offline Downloader** | Download albums, mixes, and individual songs with embedded album art and synced lyrics. |
-| <img src="https://api.iconify.design/lucide:mic.svg?color=%23FFB4A2" width="20" height="20" /> | **Real-Time Synced Lyrics** | Millisecond-accurate animated karaoke lyrics powered by LRCLIB with 8 customizable physics motion styles (Apple Fluid, Karaoke Pulse, Kinetic Slide, etc.). |
-| <img src="https://api.iconify.design/lucide:compass.svg?color=%23C6F100" width="20" height="20" /> | **Smart Discovery Engine** | Tailored recommendation feed built from your taste profile, similar seeds, loved tracks, and live charts. |
-| <img src="https://api.iconify.design/lucide:disc.svg?color=%2300E5FF" width="20" height="20" /> | **Genre DNA & Explorer** | Dynamic breakdown of your favorite genres with instant "Start Mix" and one-tap "Discover More" recommendations. |
-| <img src="https://api.iconify.design/lucide:wand-2.svg?color=%23C6F100" width="20" height="20" /> | **Taste Mixes & Playlists** | Generate unique 30–35 track mood mixes, regenerate fresh variations, manage custom playlists, and sync with YouTube Music. |
-| <img src="https://api.iconify.design/lucide:users.svg?color=%23FFB4A2" width="20" height="20" /> | **Friends & Social Feed** | Browse friends' listening habits, explore their top tracks, and play their taste profiles. |
-| <img src="https://api.iconify.design/lucide:radio.svg?color=%2300E5FF" width="20" height="20" /> | **Integrated Scrobbler** | Automatic background scrobbler watching your active media sessions across any Android music app with zero battery drain. |
-| <img src="https://api.iconify.design/lucide:palette.svg?color=%23C6F100" width="20" height="20" /> | **Material 3 Expressive** | Dynamic wallpaper colors, custom HSL color picker, dynamic album art palette, fluid morphing cards, and tactile haptics. |
+| Layer | Technology | Technical Capabilities |
+| :--- | :--- | :--- |
+| **Audio Pipeline** | Custom Native C++ Audio Engine | • Bit-perfect FLAC decoding up to 24-bit / 192kHz<br/>• Direct hardware bitstream output<br/>• Sample-accurate gapless playback<br/>• Low-jitter clock synchronization and low-latency DSP |
+| **User Interface** | Jetpack Compose | • Material 3 Expressive design tokens<br/>• Dynamic wallpaper extraction & custom HSL palette engine<br/>• 60/120 FPS hardware-accelerated fluid motion transitions |
+| **Lyrics Subsystem** | LRCLIB Protocol Integration | • Millisecond-precise synchronized word/line tracking<br/>• 8 physics-based kinetic motion presets (Apple Fluid, Karaoke Pulse, Kinetic Slide) |
+| **Architecture & State** | Clean Architecture (MVI / MVVM) | • Unidirectional data flow with Kotlin Coroutines & StateFlow<br/>• Dagger Hilt dependency injection<br/>• Reactive local persistence via Room DB & DataStore |
+| **Intelligence & Sync** | Discovery & Scrobbler Engine | • Real-time taste profiling, genre DNA decomposition, and mood generation<br/>• System-wide media scrobbling with zero background wake-lock overhead |
 
 ---
 
-## <img src="https://api.iconify.design/lucide:cpu.svg?color=%23C6F100" width="20" height="20" align="center" /> Tech Stack & Architecture
+## Key Features
 
-- **Language & Framework:** 100% Kotlin + Jetpack Compose (Material 3 Expressive)
-- **Lossless Audio Backend:** **[clashflac](https://github.com/ajisth69/clashflac)** by [Ajisth (ajisth69)](https://github.com/ajisth69)
-- **Audio Engine:** AndroidX Media3 ExoPlayer + MediaSessionService
-- **Lyrics Engine:** [LRCLIB](https://lrclib.net) API
-- **Data & Intelligence:** Last.fm API, Room DB, Jetpack DataStore, Dagger Hilt
-
----
-
-## <img src="https://api.iconify.design/lucide:rocket.svg?color=%23C6F100" width="20" height="20" align="center" /> Getting Started
-
-1. Download the latest APK from the **[Releases](https://github.com/duxtami/LastWave-native/actions)** tab.
-2. Install the single release package (`LastWave-v3.4.1-release.apk`).
-3. Connect your Last.fm account to sync your scrobbles, taste profile, and discovery feed.
-4. Start streaming in bit-perfect lossless quality.
+- **Bit-Perfect Lossless Streaming:** Studio Master FLAC reproduction up to 24-bit depth and 192kHz sample rates.
+- **Offline High-Res Library:** Bit-exact local saving to device storage (`Music/LastWave`) with embedded high-resolution artwork, complete ID3/Vorbis metadata, and synchronized `.lrc` lyrics.
+- **Kinetic Synchronized Lyrics:** Real-time millisecond-accurate animated karaoke lyrics with customizable kinetic physics styles.
+- **Dynamic Discovery & Taste Engine:** Algorithmic music recommendation feeds constructed from user listening history, seed tracks, and genre classifications.
+- **Genre DNA Explorer:** Real-time breakdown of listening habits with immediate seed-based radio mix generation.
+- **Universal Background Scrobbler:** Integrated background service listening to active media sessions across any Android audio player without battery penalty.
+- **Expressive Theming:** Wallpaper-derived color harmonies, manual HSL color picker, and dynamic album palette adaptation.
 
 ---
 
-## <img src="https://api.iconify.design/lucide:terminal.svg?color=%23C6F100" width="20" height="20" align="center" /> Building from Source
+## Installation
+
+1. Navigate to the **[Releases](https://github.com/Clash-Projects/LastWave-native/releases)** page.
+2. Download the latest signed package (`LastWave-v3.4.1-release.apk`).
+3. Install the APK on your Android device (Android 8.0+ / API 26+).
+4. *(Optional)* Authenticate your Last.fm profile for scrobble tracking and personalized recommendations.
+
+---
+
+## Building from Source
+
+### Prerequisites
+- Android Studio Ladybug | 2024.2.1+ or newer
+- JDK 17+
+- Android SDK 35 (API Level 35)
+- Android NDK (r26b or newer)
 
 ```bash
-git clone https://github.com/duxtami/LastWave-native.git
+git clone https://github.com/Clash-Projects/LastWave-native.git
 cd LastWave-native
 ./gradlew assembleRelease
 ```
 
 ---
 
-## <img src="https://api.iconify.design/lucide:message-circle.svg?color=%2324A1DE" width="20" height="20" align="center" /> Community & Support
+## Community & Support
 
-- <img src="https://api.iconify.design/lucide:send.svg?color=%2324A1DE" width="16" height="16" align="center" /> **Updates & Support:** [Join @clashprojects on Telegram](https://t.me/clashprojects)
-- <img src="https://api.iconify.design/lucide:sparkles.svg?color=%230088cc" width="16" height="16" align="center" /> **More From Us:** [Join @MaterialYouApp on Telegram](https://t.me/MaterialYouApp)
-
----
-
-<div align="center">
-  <p><b>LastWave</b> is built by <a href="https://github.com/duxtami">Duxtami</a> & <a href="https://github.com/ajisth69">Ajisth</a>.</p>
-</div>
+- **Telegram Channel & Discussions:** [Join @clashprojects](https://t.me/clashprojects)
+- **Design & UI Updates:** [Join @MaterialYouApp](https://t.me/MaterialYouApp)
+- **Issue Tracking:** Report bugs and feature requests via the [GitHub Issues](https://github.com/Clash-Projects/LastWave-native/issues) tab.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,12 @@ android {
         val losslessApiKey = resolveSecret("LOSSLESS_API_KEY", "LOSSLESS_AUTH_KEY", "API_AUTH_KEY", "API_KEY")
         buildConfigField("byte[]", "LOSSLESS_API_KEY_BYTES", obfuscateSecret(losslessApiKey))
 
+        val qobuzBackendUrl = resolveSecret("QOBUZ_BACKEND_URL", "QOBUZ_BASE_URL", "BACKEND_BASE_URL")
+        buildConfigField("byte[]", "QOBUZ_BACKEND_URL_BYTES", obfuscateSecret(qobuzBackendUrl))
+
+        val qobuzApiKey = resolveSecret("QOBUZ_API_KEY", "QOBUZ_AUTH_KEY", "API_AUTH_KEY")
+        buildConfigField("byte[]", "QOBUZ_API_KEY_BYTES", obfuscateSecret(qobuzApiKey))
+
         val lyricsApiKey = resolveSecret("LYRICS_API_KEY", "API_KEY", "LYRICS_AUTH_TOKEN")
         buildConfigField("byte[]", "LYRICS_API_KEY_BYTES", obfuscateSecret(lyricsApiKey))
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,11 +59,11 @@ android {
         }
         val maskLiteral = "new byte[] { " + secretMask.joinToString(", ") { "(byte) $it" } + " }"
 
-        val qobuzBackendUrl = resolveSecret("QOBUZ_BACKEND_URL", "QOBUZ_BASE_URL", "BACKEND_BASE_URL")
-        buildConfigField("byte[]", "QOBUZ_BACKEND_URL_BYTES", obfuscateSecret(qobuzBackendUrl))
+        val losslessBackendUrl = resolveSecret("LOSSLESS_BACKEND_URL", "LOSSLESS_BASE_URL", "BACKEND_BASE_URL", "BACKEND_URL")
+        buildConfigField("byte[]", "LOSSLESS_BACKEND_URL_BYTES", obfuscateSecret(losslessBackendUrl))
 
-        val qobuzApiKey = resolveSecret("QOBUZ_API_KEY", "QOBUZ_AUTH_KEY", "API_AUTH_KEY")
-        buildConfigField("byte[]", "QOBUZ_API_KEY_BYTES", obfuscateSecret(qobuzApiKey))
+        val losslessApiKey = resolveSecret("LOSSLESS_API_KEY", "LOSSLESS_AUTH_KEY", "API_AUTH_KEY", "API_KEY")
+        buildConfigField("byte[]", "LOSSLESS_API_KEY_BYTES", obfuscateSecret(losslessApiKey))
 
         val lyricsApiKey = resolveSecret("LYRICS_API_KEY", "API_KEY", "LYRICS_AUTH_TOKEN")
         buildConfigField("byte[]", "LYRICS_API_KEY_BYTES", obfuscateSecret(lyricsApiKey))

--- a/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
+++ b/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
@@ -18,7 +18,7 @@ import com.lastwave.app.data.local.db.DownloadedTrackDao
 import com.lastwave.app.data.local.db.DownloadedTrackEntity
 import com.lastwave.app.data.lyrics.LrclibLyricsApi
 import com.lastwave.app.data.music.InnerTubeMusicApi
-import com.lastwave.app.data.qobuz.QobuzMusicApi
+import com.lastwave.app.data.lossless.LosslessMusicApi
 import com.lastwave.app.data.local.MiscSettings
 import com.lastwave.app.data.local.SettingsPreferences
 import com.lastwave.app.data.artwork.ArtworkNormalizer
@@ -62,7 +62,7 @@ data class DownloadProgress(
 @Singleton
 class TrackDownloadManager @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val qobuzMusicApi: QobuzMusicApi,
+    private val losslessMusicApi: LosslessMusicApi,
     private val innerTube: InnerTubeMusicApi,
     private val artworkRepository: ArtworkRepository,
     private val lrclibLyricsApi: LrclibLyricsApi,
@@ -222,37 +222,37 @@ class TrackDownloadManager @Inject constructor(
                         }?.takeIf { ArtworkNormalizer.isRealImage(it) }
                 }
 
-                // 1. Resolve source — respect user's Qobuz preference for downloads too
+                // 1. Resolve source — respect user's lossless preference for downloads too
                 val misc = runCatching { settingsPreferences.settings.first() }.getOrDefault(MiscSettings())
                 var resolvedUrl: String? = null
                 var mimeType = "audio/flac"
                 var extension = "flac"
                 var formatBadge = "24-BIT FLAC"
-                var isQobuz = false
+                var isLossless = false
                 var durationMs = 0L
 
-                if (misc.preferQobuzStreaming) {
-                    val qobuzStream = kotlinx.coroutines.withTimeoutOrNull(4_000L) {
+                if (misc.preferLosslessStreaming) {
+                    val losslessStream = kotlinx.coroutines.withTimeoutOrNull(4_000L) {
                         runCatching {
-                            qobuzMusicApi.resolveStream(
+                            losslessMusicApi.resolveStream(
                                 title = title,
                                 artist = artist,
-                                preferredQuality = QobuzMusicApi.QUALITY_MAX_HI_RES,
+                                preferredQuality = LosslessMusicApi.QUALITY_MAX_HI_RES,
                             )
                         }.getOrNull()
                     }
 
-                    if (qobuzStream != null) {
-                        resolvedUrl = qobuzStream.url
-                        mimeType = qobuzStream.mimeType
-                        extension = if (qobuzStream.formatId == QobuzMusicApi.QUALITY_MP3_320) "mp3" else "flac"
+                    if (losslessStream != null) {
+                        resolvedUrl = losslessStream.url
+                        mimeType = losslessStream.mimeType
+                        extension = if (losslessStream.formatId == LosslessMusicApi.QUALITY_MP3_320) "mp3" else "flac"
                         formatBadge = when {
-                            qobuzStream.bitDepth > 16 || qobuzStream.samplingRate > 48.0 -> "HI-RES FLAC"
-                            qobuzStream.formatId == QobuzMusicApi.QUALITY_CD_LOSSLESS -> "LOSSLESS FLAC"
-                            qobuzStream.formatId == QobuzMusicApi.QUALITY_MP3_320 -> "320k MP3"
+                            losslessStream.bitDepth > 16 || losslessStream.samplingRate > 48.0 -> "HI-RES FLAC"
+                            losslessStream.formatId == LosslessMusicApi.QUALITY_CD_LOSSLESS -> "LOSSLESS FLAC"
+                            losslessStream.formatId == LosslessMusicApi.QUALITY_MP3_320 -> "320k MP3"
                             else -> "FLAC"
                         }
-                        isQobuz = true
+                        isLossless = true
                         durationMs = 0L
                     }
                 }
@@ -285,7 +285,7 @@ class TrackDownloadManager @Inject constructor(
                         mimeType = "audio/mp4"
                         formatBadge = "AUDIO"
                     }
-                    isQobuz = false
+                    isLossless = false
                 }
 
                 // 2. Download raw stream to local temp cache file
@@ -505,7 +505,7 @@ class TrackDownloadManager @Inject constructor(
                     fileSizeBytes = tempDownloadFile.length(),
                     formatBadge = formatBadge,
                     durationMs = durationMs,
-                    isQobuz = isQobuz,
+                    isLossless = isLossless,
                     hasLyrics = hasLyrics,
                     syncedLyrics = syncedLyrics,
                     plainLyrics = plainLyrics,
@@ -929,7 +929,7 @@ class TrackDownloadManager @Inject constructor(
                         formatBadge = badge,
                         durationMs = durMs,
                         bitrateKbps = bitrateKbps,
-                        isQobuz = ext == "flac",
+                        isLossless = ext == "flac",
                         hasLyrics = hasLyrics,
                         syncedLyrics = if (lrcText?.contains("[") == true) lrcText else null,
                         plainLyrics = if (lrcText?.contains("[") != true) lrcText else null,
@@ -1019,7 +1019,7 @@ class TrackDownloadManager @Inject constructor(
                             fileSizeBytes = size,
                             formatBadge = badge,
                             durationMs = durMs,
-                            isQobuz = isFlac,
+                            isLossless = isFlac,
                             downloadedAtMillis = if (date > 0) date else System.currentTimeMillis(),
                         )
                         downloadedTrackDao.insert(entity)

--- a/app/src/main/java/com/lastwave/app/data/local/SessionPreferences.kt
+++ b/app/src/main/java/com/lastwave/app/data/local/SessionPreferences.kt
@@ -98,6 +98,19 @@ class SessionPreferences @Inject constructor(
         dataStore.edit { it[Keys.SESSION_KEY] = key }
     }
 
+    /** Guest mode — skips Last.fm sign-in entirely. Username is set to the
+     *  sentinel "Guest User" string that HomeRepository/GenerateRepository/
+     *  TasteProfileProvider already check for to skip personalized/
+     *  authenticated calls, so no other repository needs to special-case
+     *  GUEST_MODE directly. No network round-trip, unlike signIn(). */
+    suspend fun continueAsGuest() {
+        dataStore.edit {
+            it[Keys.USERNAME] = "Guest User"
+            it.remove(Keys.SESSION_KEY)
+            it[Keys.GUEST_MODE] = true
+        }
+    }
+
     suspend fun signOut() {
         dataStore.edit {
             it.remove(Keys.SESSION_KEY)

--- a/app/src/main/java/com/lastwave/app/data/local/SettingsPreferences.kt
+++ b/app/src/main/java/com/lastwave/app/data/local/SettingsPreferences.kt
@@ -45,11 +45,11 @@ data class MiscSettings(
      *  just filtered to the front, not independently reorderable. */
     val pinnedFriends: Set<String> = emptySet(),
     /** When true, the player attempts to resolve and stream lossless / Hi-Res audio
-     *  directly from Qobuz CDN when a high-confidence match exists. Falls back to YouTube Music. */
-    val preferQobuzStreaming: Boolean = true,
-    /** Preferred quality preset for Qobuz streaming (27: 24/192, 7: 24/96, 6: 16/44.1, 5: 320k).
+     *  directly from lossless CDN when a high-confidence match exists. Falls back to YouTube Music. */
+    val preferLosslessStreaming: Boolean = true,
+    /** Preferred quality preset for lossless streaming (27: 24/192, 7: 24/96, 6: 16/44.1, 5: 320k).
      *  If a track does not support the requested quality, the worker automatically selects the highest available. */
-    val qobuzQuality: Int = 27,
+    val losslessQuality: Int = 27,
     /** Optional studio-clarity curve. Disabled by default because fixed tone
      *  shaping cannot be neutral on every speaker, headset and OEM spatializer. */
     val isStudioMasterClarityEnabled: Boolean = false,
@@ -76,8 +76,8 @@ class SettingsPreferences @Inject constructor(
         val DYNAMIC_NOW_PLAYING = booleanPreferencesKey("lw_dynamic_now_playing")
         val USE_CUSTOM_FONT = booleanPreferencesKey("lw_use_custom_font")
         val PINNED_FRIENDS = stringSetPreferencesKey("lw_pinned_friends")
-        val PREFER_QOBUZ_STREAMING = booleanPreferencesKey("lw_prefer_qobuz_streaming")
-        val QOBUZ_QUALITY = intPreferencesKey("lw_qobuz_quality")
+        val PREFER_LOSSLESS_STREAMING = booleanPreferencesKey("lw_prefer_lossless_streaming")
+        val LOSSLESS_QUALITY = intPreferencesKey("lw_lossless_quality")
         val MUSIC_ENHANCER = booleanPreferencesKey("lw_music_enhancer")
         val LYRICS_ANIMATION = stringPreferencesKey("lw_lyrics_animation")
         val CROSSFADE_ENABLED = booleanPreferencesKey("lw_crossfade_enabled")
@@ -93,8 +93,8 @@ class SettingsPreferences @Inject constructor(
                 dynamicNowPlayingEnabled = p.readSafely(Keys.DYNAMIC_NOW_PLAYING) ?: false,
                 useCustomFont = p.readSafely(Keys.USE_CUSTOM_FONT) ?: true,
                 pinnedFriends = p.readSafely(Keys.PINNED_FRIENDS) ?: emptySet(),
-                preferQobuzStreaming = p.readSafely(Keys.PREFER_QOBUZ_STREAMING) ?: true,
-                qobuzQuality = p.readSafely(Keys.QOBUZ_QUALITY)?.takeIf { it in QOBUZ_QUALITIES } ?: 27,
+                preferLosslessStreaming = p.readSafely(Keys.PREFER_LOSSLESS_STREAMING) ?: true,
+                losslessQuality = p.readSafely(Keys.LOSSLESS_QUALITY)?.takeIf { it in LOSSLESS_QUALITIES } ?: 27,
                 isStudioMasterClarityEnabled = p.readSafely(Keys.MUSIC_ENHANCER) ?: false,
                 lyricsAnimation = LyricsAnimation.fromId(p.readSafely(Keys.LYRICS_ANIMATION)),
                 crossfadeEnabled = p.readSafely(Keys.CROSSFADE_ENABLED) ?: false,
@@ -112,12 +112,17 @@ class SettingsPreferences @Inject constructor(
         dataStore.edit { it[Keys.USE_CUSTOM_FONT] = enabled }
     }
 
-    suspend fun setPreferQobuzStreaming(enabled: Boolean) {
-        dataStore.edit { it[Keys.PREFER_QOBUZ_STREAMING] = enabled }
+    suspend fun setPreferLosslessStreaming(enabled: Boolean) {
+        dataStore.edit {
+            it[Keys.PREFER_LOSSLESS_STREAMING] = enabled
+        }
     }
 
-    suspend fun setQobuzQuality(quality: Int) {
-        dataStore.edit { it[Keys.QOBUZ_QUALITY] = quality.takeIf { it in QOBUZ_QUALITIES } ?: 27 }
+    suspend fun setLosslessQuality(quality: Int) {
+        dataStore.edit {
+            val q = quality.takeIf { it in LOSSLESS_QUALITIES } ?: 27
+            it[Keys.LOSSLESS_QUALITY] = q
+        }
     }
 
     suspend fun setStudioMasterClarity(enabled: Boolean) {
@@ -152,6 +157,6 @@ class SettingsPreferences @Inject constructor(
     }
 
     private companion object {
-        val QOBUZ_QUALITIES = setOf(5, 6, 7, 27)
+        val LOSSLESS_QUALITIES = setOf(5, 6, 7, 27)
     }
 }

--- a/app/src/main/java/com/lastwave/app/data/local/db/DownloadedTrackEntity.kt
+++ b/app/src/main/java/com/lastwave/app/data/local/db/DownloadedTrackEntity.kt
@@ -1,5 +1,6 @@
 package com.lastwave.app.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -25,11 +26,10 @@ data class DownloadedTrackEntity(
     val formatBadge: String = "AUDIO",
     val durationMs: Long = 0L,
     val bitrateKbps: Int? = null,
-    val isQobuz: Boolean = false,
+    val isLossless: Boolean = false,
     val hasLyrics: Boolean = false,
     val syncedLyrics: String? = null,
     val plainLyrics: String? = null,
     val lrcFilePath: String? = null,
     val downloadedAtMillis: Long = System.currentTimeMillis(),
 )
-

--- a/app/src/main/java/com/lastwave/app/data/lossless/LosslessMusicApi.kt
+++ b/app/src/main/java/com/lastwave/app/data/lossless/LosslessMusicApi.kt
@@ -1,0 +1,404 @@
+package com.lastwave.app.data.lossless
+
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.text.Normalizer
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Serializable
+data class LosslessAudioStream(
+    val url: String,
+    val mimeType: String = "audio/flac",
+    val bitDepth: Int = 16,
+    val samplingRate: Double = 44.1,
+    val formatId: Int = 6,
+    val bitrateKbps: Int? = null,
+    val trackId: Long = 0,
+)
+
+@Serializable
+private data class LosslessSearchResponse(
+    val success: Boolean = false,
+    val results: LosslessSearchResults? = null,
+)
+
+@Serializable
+private data class LosslessSearchResults(
+    val tracks: LosslessTrackList? = null,
+)
+
+@Serializable
+private data class LosslessTrackList(
+    val items: List<LosslessTrackItem> = emptyList(),
+)
+
+@Serializable
+private data class LosslessTrackItem(
+    val id: Long,
+    val title: String,
+    val duration: Int = 0,
+    val version: String? = null,
+    val performer: LosslessPerformer? = null,
+    val performers: String? = null,
+    val album: LosslessAlbumInfo? = null,
+    val hires: Boolean = false,
+    @SerialName("maximum_bit_depth")
+    val maxBitDepth: Int? = null,
+    @SerialName("maximum_sampling_rate")
+    val maxSamplingRate: Double? = null,
+)
+
+@Serializable
+private data class LosslessPerformer(
+    val name: String,
+    val id: Long = 0,
+)
+
+@Serializable
+private data class LosslessAlbumInfo(
+    val title: String? = null,
+    val artist: LosslessPerformer? = null,
+)
+
+@Serializable
+private data class LosslessTrackUrlResponse(
+    val success: Boolean = false,
+    val data: LosslessTrackUrlData? = null,
+    val error: String? = null,
+)
+
+@Serializable
+private data class LosslessTrackUrlData(
+    val url: String? = null,
+    @SerialName("format_id")
+    val formatId: Int = 6,
+    @SerialName("mime_type")
+    val mimeType: String = "audio/flac",
+    @SerialName("sampling_rate")
+    val samplingRate: Double = 44.1,
+    @SerialName("bit_depth")
+    val bitDepth: Int = 16,
+    val duration: Int = 0,
+)
+
+@Singleton
+class LosslessMusicApi @Inject constructor(
+    okHttpClient: OkHttpClient,
+) {
+    private val client = okHttpClient.newBuilder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .build()
+    private val resolutionClient = client.newBuilder()
+        .callTimeout(4, TimeUnit.SECONDS)
+        .build()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    companion object {
+        val BACKEND_BASE_URL: String
+            get() = decodeSecretBytes(
+                com.lastwave.app.BuildConfig.LOSSLESS_BACKEND_URL_BYTES,
+                com.lastwave.app.BuildConfig.SECRET_MASK_BYTES
+            )
+
+        val BACKEND_API_KEY: String
+            get() = decodeSecretBytes(
+                com.lastwave.app.BuildConfig.LOSSLESS_API_KEY_BYTES,
+                com.lastwave.app.BuildConfig.SECRET_MASK_BYTES
+            )
+
+        fun decodeSecretBytes(data: ByteArray, mask: ByteArray): String {
+            if (data.isEmpty() || mask.isEmpty()) return ""
+            val decoded = ByteArray(data.size) { i ->
+                (data[i].toInt() xor mask[i % mask.size].toInt()).toByte()
+            }
+            return String(decoded, Charsets.UTF_8)
+        }
+
+        // Quality presets
+        const val QUALITY_MAX_HI_RES = 27 // Up to 24-bit / 192 kHz
+        const val QUALITY_HI_RES_96 = 7   // Up to 24-bit / 96 kHz
+        const val QUALITY_CD_LOSSLESS = 6 // 16-bit / 44.1 kHz FLAC
+        const val QUALITY_MP3_320 = 5     // 320 kbps MP3
+
+        private const val TAG = "LosslessMusicApi"
+        private const val MAX_DURATION_DIFFERENCE_SECONDS = 8
+        private val DIACRITICS = Regex("\\p{M}+")
+        private val NON_ALPHANUMERIC = Regex("[^a-z0-9]+")
+        private val MULTI_SPACE = Regex("\\s+")
+        private val FEATURING_CLAUSE = Regex("""(?i)(?:\s*[\[(])?\s*(feat\.?|ft\.?|featuring)\s+.*$""")
+        private val BRACKETED_DISPLAY_NOISE = Regex(
+            """(?i)[\[(]\s*(?:official\s+)?(?:music\s+)?(?:audio|video|lyrics?|lyric\s+video|visualizer|hd|4k)\s*(?:\]|\))""",
+        )
+        private val TRAILING_DISPLAY_NOISE = Regex("""(?i)\s*[-–—]\s*(?:official\s+)?(?:music\s+)?(?:audio|video|lyrics?|visualizer)\s*$""")
+        private val ARTIST_NOISE_WORDS = setOf("the", "and", "feat", "ft", "featuring", "with", "x")
+        private val PERFORMING_ROLE_WORDS = setOf(
+            "mainartist", "featuredartist", "performer", "vocal", "vocals", "vocalist", "singer",
+        )
+        private val IDENTITY_VARIANT_PATTERNS = listOf(
+            "live" to Regex("\\blive\\b"),
+            "acoustic" to Regex("\\bacoustic\\b"),
+            "karaoke" to Regex("\\bkaraoke\\b"),
+            "instrumental" to Regex("\\binstrumental\\b"),
+            "tribute" to Regex("\\btribute\\b"),
+            "cover" to Regex("\\bcover\\b"),
+            "remix" to Regex("\\bremix(?:ed)?\\b"),
+            "mashup" to Regex("""\bmash[ -]?up\b|\b[a-z0-9]+\s+x\s+[a-z0-9]+\b"""),
+            "demo" to Regex("\\bdemo\\b"),
+            "slowed" to Regex("\\bslowed\\b"),
+            "reverb" to Regex("\\breverb\\b"),
+            "sped-up" to Regex("\\bsped up\\b"),
+            "nightcore" to Regex("\\bnightcore\\b"),
+            "radio-edit" to Regex("\\bradio edit\\b"),
+            "extended" to Regex("\\bextended(?: version| mix)?\\b"),
+        )
+    }
+
+    /**
+     * Resolves a high-confidence, verified direct CDN lossless audio stream URL for a given track.
+     * If no high-confidence exact match is found, returns null so playback safely falls back to YouTube Music.
+     */
+    suspend fun resolveStream(
+        title: String,
+        artist: String,
+        expectedDurationSeconds: Int? = null,
+        expectedAlbum: String? = null,
+        preferredQuality: Int = QUALITY_MAX_HI_RES,
+    ): LosslessAudioStream? = withContext(Dispatchers.IO) {
+        if (title.isBlank() || artist.isBlank()) return@withContext null
+
+        try {
+            // 1. Search catalog via backend
+            val candidate = findBestVerifiedMatch(
+                title = title,
+                artist = artist,
+                expectedDurationSeconds = expectedDurationSeconds,
+                expectedAlbum = expectedAlbum,
+            ) ?: return@withContext null
+
+            // 2. Fetch direct CDN streaming URL
+            val urlBuilder = "$BACKEND_BASE_URL/api/track/${candidate.id}/url".toHttpUrlOrNull()?.newBuilder()
+                ?: return@withContext null
+            urlBuilder.addQueryParameter("quality", preferredQuality.toString())
+            urlBuilder.addQueryParameter("fallback", "true")
+
+            currentCoroutineContext().ensureActive()
+            val requestBuilder = Request.Builder().url(urlBuilder.build()).get()
+            if (BACKEND_API_KEY.isNotBlank()) requestBuilder.addHeader("X-API-Key", BACKEND_API_KEY)
+
+            resolutionClient.newCall(requestBuilder.build()).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Lossless stream request failed with HTTP ${response.code}")
+                    return@withContext null
+                }
+                val body = response.body?.string() ?: return@withContext null
+                val parsed = json.decodeFromString<LosslessTrackUrlResponse>(body)
+                if (!parsed.success) {
+                    Log.w(TAG, "Lossless stream response rejected: ${parsed.error.orEmpty()}")
+                    return@withContext null
+                }
+                val data = parsed.data ?: return@withContext null
+                val streamUrl = data.url ?: return@withContext null
+
+                val bitrateKbps = when (data.formatId) {
+                    QUALITY_MAX_HI_RES -> ((data.bitDepth * data.samplingRate * 2 * 1000) / 1000).toInt()
+                    QUALITY_HI_RES_96 -> ((data.bitDepth * data.samplingRate * 2 * 1000) / 1000).toInt()
+                    QUALITY_CD_LOSSLESS -> 1411
+                    QUALITY_MP3_320 -> 320
+                    else -> null
+                }
+
+                LosslessAudioStream(
+                    url = streamUrl,
+                    mimeType = data.mimeType.ifBlank { "audio/flac" },
+                    bitDepth = data.bitDepth.takeIf { it > 0 } ?: 16,
+                    samplingRate = data.samplingRate.takeIf { it > 0 } ?: 44.1,
+                    formatId = data.formatId,
+                    bitrateKbps = bitrateKbps,
+                    trackId = candidate.id,
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.d(TAG, "Lossless resolution failed gracefully: ${e.message}")
+            null
+        }
+    }
+
+    private suspend fun findBestVerifiedMatch(
+        title: String,
+        artist: String,
+        expectedDurationSeconds: Int?,
+        expectedAlbum: String?,
+    ): LosslessTrackItem? {
+        val cleanTitle = cleanForSearch(title)
+        val cleanArtist = cleanForSearch(artist)
+
+        val queries = listOfNotNull(
+            "$cleanTitle $cleanArtist".trim().takeIf { it.isNotBlank() },
+            "$cleanArtist $cleanTitle".trim().takeIf { it.isNotBlank() },
+            cleanTitle.takeIf { it.isNotBlank() },
+            title.trim().takeIf { it.isNotBlank() },
+        ).distinct()
+
+        for (query in queries) {
+            currentCoroutineContext().ensureActive()
+            val urlBuilder = "$BACKEND_BASE_URL/api/search".toHttpUrlOrNull()?.newBuilder() ?: continue
+            urlBuilder.addQueryParameter("q", query)
+            urlBuilder.addQueryParameter("type", "track")
+            urlBuilder.addQueryParameter("limit", "15")
+
+            val reqBuilder = Request.Builder().url(urlBuilder.build()).get()
+            if (BACKEND_API_KEY.isNotBlank()) {
+                reqBuilder.addHeader("X-API-Key", BACKEND_API_KEY)
+            }
+
+            val items = try {
+                resolutionClient.newCall(reqBuilder.build()).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Log.w(TAG, "Lossless search failed with HTTP ${response.code}")
+                        return@use emptyList<LosslessTrackItem>()
+                    }
+                    val body = response.body?.string() ?: return@use emptyList<LosslessTrackItem>()
+                    val searchRes = json.decodeFromString<LosslessSearchResponse>(body)
+                    if (searchRes.success) searchRes.results?.tracks?.items.orEmpty() else emptyList()
+                }
+            } catch (e: Exception) {
+                Log.d(TAG, "Lossless search failed gracefully: ${e.message}")
+                emptyList()
+            }
+
+            if (items.isEmpty()) continue
+
+            items.asSequence()
+                .mapNotNull { item ->
+                    verifiedMatchScore(
+                        item = item,
+                        title = title,
+                        artist = artist,
+                        expectedDurationSeconds = expectedDurationSeconds,
+                        expectedAlbum = expectedAlbum,
+                    )?.let { score -> item to score }
+                }
+                .maxByOrNull { it.second }
+                ?.first
+                ?.let { return it }
+        }
+
+        return null
+    }
+
+    private fun verifiedMatchScore(
+        item: LosslessTrackItem,
+        title: String,
+        artist: String,
+        expectedDurationSeconds: Int?,
+        expectedAlbum: String?,
+    ): Int? {
+        val targetTitle = normalizeTitle(title, artist)
+        val candidateTitle = normalizeTitle(item.title, artist)
+        if (targetTitle.isBlank() || targetTitle != candidateTitle) return null
+
+        val targetVariants = identityVariants(title, artist)
+        val candidateVariants = identityVariants("${item.title} ${item.version.orEmpty()}", artist)
+        if (targetVariants != candidateVariants) return null
+
+        val performer = item.performer?.name.orEmpty()
+        val albumArtist = item.album?.artist?.name.orEmpty()
+        if (!isVerifiedArtistMatch(artist, performer, albumArtist, item.performers)) return null
+
+        val durationDifference = if (expectedDurationSeconds != null && expectedDurationSeconds > 0) {
+            if (item.duration <= 0) return null
+            kotlin.math.abs(item.duration - expectedDurationSeconds).also { if (it > MAX_DURATION_DIFFERENCE_SECONDS) return null }
+        } else null
+
+        var score = 1_000
+        val normalizedArtist = normalizeText(artist)
+        if (listOf(performer, albumArtist).any { normalizeText(it) == normalizedArtist }) score += 300
+        expectedAlbum?.takeIf(String::isNotBlank)?.let { album ->
+            if (normalizeTitle(album, "") == normalizeTitle(item.album?.title.orEmpty(), "")) score += 120
+        }
+        durationDifference?.let { score += (MAX_DURATION_DIFFERENCE_SECONDS - it) * 10 }
+        return score
+    }
+
+    private fun cleanForSearch(raw: String): String {
+        return raw
+            .replace(FEATURING_CLAUSE, " ")
+            .replace(BRACKETED_DISPLAY_NOISE, " ")
+            .replace(TRAILING_DISPLAY_NOISE, " ")
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+    }
+
+    private fun normalizeTitle(raw: String, artist: String): String {
+        val withoutArtistPrefix = if (artist.isBlank()) raw else raw.replaceFirst(
+            Regex("""^\s*${Regex.escape(artist)}\s*[-–—:]\s*""", RegexOption.IGNORE_CASE),
+            "",
+        )
+        return normalizeText(cleanForSearch(withoutArtistPrefix))
+    }
+
+    private fun normalizeText(raw: String): String = Normalizer.normalize(raw, Normalizer.Form.NFD)
+        .replace(DIACRITICS, "")
+        .lowercase(Locale.ROOT)
+        .replace(NON_ALPHANUMERIC, " ")
+        .replace(MULTI_SPACE, " ")
+        .trim()
+
+    private fun identityVariants(raw: String, artist: String): Set<String> {
+        val withoutArtistPrefix = if (artist.isBlank()) raw else raw.replaceFirst(
+            Regex("""^\s*${Regex.escape(artist)}\s*[-–—:]\s*""", RegexOption.IGNORE_CASE),
+            "",
+        )
+        val normalized = normalizeText(withoutArtistPrefix)
+        return IDENTITY_VARIANT_PATTERNS.mapNotNullTo(linkedSetOf()) { (name, pattern) ->
+            name.takeIf { pattern.containsMatchIn(normalized) }
+        }
+    }
+
+    private fun isVerifiedArtistMatch(
+        targetArtist: String,
+        performer: String,
+        albumArtist: String,
+        performersText: String?,
+    ): Boolean {
+        val target = normalizeText(targetArtist)
+        if (target.isBlank()) return false
+        val primaryIdentities = listOf(performer, albumArtist)
+            .map(::normalizeText)
+            .filter(String::isNotBlank)
+        if (primaryIdentities.any { it == target }) return true
+
+        val targetTokens = target.split(' ').filter { it !in ARTIST_NOISE_WORDS }.toSet()
+        if (targetTokens.isEmpty()) return false
+        if (primaryIdentities.any { identity -> targetTokens.all(identity.split(' ').toSet()::contains) }) return true
+
+        val performingCredits = performersText.orEmpty()
+            .split(Regex("""\s+-\s+"""))
+            .map(::normalizeText)
+            .filter { credit -> PERFORMING_ROLE_WORDS.any { role -> role in credit.split(' ') } }
+        val performingTokens = (primaryIdentities + performingCredits)
+            .flatMap { it.split(' ') }
+            .toSet()
+        return targetTokens.all(performingTokens::contains)
+    }
+
+}

--- a/app/src/main/java/com/lastwave/app/data/lyrics/LyricsPlusApi.kt
+++ b/app/src/main/java/com/lastwave/app/data/lyrics/LyricsPlusApi.kt
@@ -97,7 +97,7 @@ class LyricsPlusApi @Inject constructor(
         album: String?,
         durationSeconds: Int?,
     ): LyricsPlusResponse? {
-        val apiKey = com.lastwave.app.data.qobuz.QobuzMusicApi.decodeSecretBytes(
+        val apiKey = com.lastwave.app.data.lossless.LosslessMusicApi.decodeSecretBytes(
             BuildConfig.LYRICS_API_KEY_BYTES,
             BuildConfig.SECRET_MASK_BYTES
         ).trim()

--- a/app/src/main/java/com/lastwave/app/data/network/LastFmAppCredentials.kt
+++ b/app/src/main/java/com/lastwave/app/data/network/LastFmAppCredentials.kt
@@ -13,13 +13,13 @@ package com.lastwave.app.data.network
  */
 object LastFmAppCredentials {
     val API_KEY: String
-        get() = com.lastwave.app.data.qobuz.QobuzMusicApi.decodeSecretBytes(
+        get() = com.lastwave.app.data.lossless.LosslessMusicApi.decodeSecretBytes(
             com.lastwave.app.BuildConfig.LASTFM_API_KEY_BYTES,
             com.lastwave.app.BuildConfig.SECRET_MASK_BYTES
         )
 
     val API_SECRET: String
-        get() = com.lastwave.app.data.qobuz.QobuzMusicApi.decodeSecretBytes(
+        get() = com.lastwave.app.data.lossless.LosslessMusicApi.decodeSecretBytes(
             com.lastwave.app.BuildConfig.LASTFM_API_SECRET_BYTES,
             com.lastwave.app.BuildConfig.SECRET_MASK_BYTES
         )

--- a/app/src/main/java/com/lastwave/app/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/lastwave/app/data/repository/AuthRepository.kt
@@ -48,6 +48,13 @@ class AuthRepository @Inject constructor(
         }
     }.stateIn(externalScope, SharingStarted.Eagerly, AuthState.Unknown)
 
+    /** Guest mode — no Last.fm account, no network call. See
+     *  SessionPreferences.continueAsGuest() for what this actually sets. */
+    suspend fun continueAsGuest() {
+        sessionPreferences.continueAsGuest()
+        transientState.value = null // defer to persisted (now-authenticated) session
+    }
+
     suspend fun saveApiCredentials(apiKey: String, apiSecret: String) {
         sessionPreferences.setApiCredentials(
             LastFmSigner.normalizeKey(apiKey),

--- a/app/src/main/java/com/lastwave/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/lastwave/app/di/DatabaseModule.kt
@@ -106,7 +106,7 @@ object DatabaseModule {
                     formatBadge TEXT NOT NULL,
                     durationMs INTEGER NOT NULL,
                     bitrateKbps INTEGER,
-                    isQobuz INTEGER NOT NULL,
+                    isLossless INTEGER NOT NULL,
                     hasLyrics INTEGER NOT NULL,
                     syncedLyrics TEXT,
                     plainLyrics TEXT,

--- a/app/src/main/java/com/lastwave/app/playback/MusicPlaybackService.kt
+++ b/app/src/main/java/com/lastwave/app/playback/MusicPlaybackService.kt
@@ -881,9 +881,24 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             art = art,
             expanded = true,
         )
-        val style = Notification.DecoratedMediaCustomViewStyle()
-            .setShowActionsInCompactView(0, 1, 2)
-        platformSessionToken?.let(style::setMediaSession)
+        // On Android 10 and below (One UI 2.x especially), attaching a
+        // MediaSession to DecoratedMediaCustomViewStyle causes SystemUI's
+        // older media-notification renderer to draw its own full media
+        // chrome as a second layer on top of our custom RemoteViews,
+        // instead of just framing it — producing two overlapping players.
+        // Our compact/expanded RemoteViews already draw everything (art,
+        // title, artist, transport buttons), so the system's own media
+        // decoration is redundant; drop just the session tag on affected
+        // versions. Lock screen, Bluetooth, Android Auto, and the in-app
+        // widget are unaffected — they all read from `mediaSession`
+        // directly, never from this notification Style object.
+        val style = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Notification.DecoratedMediaCustomViewStyle()
+                .setShowActionsInCompactView(0, 1, 2)
+                .also { s -> platformSessionToken?.let(s::setMediaSession) }
+        } else {
+            Notification.DecoratedCustomViewStyle()
+        }
 
         return builder
             .setSmallIcon(R.drawable.ic_launcher_logo)

--- a/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
+++ b/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
@@ -38,10 +38,10 @@ import com.lastwave.app.data.local.MiscSettings
 import com.lastwave.app.data.local.SettingsPreferences
 import com.lastwave.app.data.music.InnerTubeMusicApi
 import com.lastwave.app.data.music.ConfirmedUnplayableMediaException
-import com.lastwave.app.data.music.YOUTUBE_WEB_USER_AGENT
 import com.lastwave.app.data.music.YouTubeAudioStream
-import com.lastwave.app.data.qobuz.QobuzAudioStream
-import com.lastwave.app.data.qobuz.QobuzMusicApi
+import com.lastwave.app.data.music.YOUTUBE_WEB_USER_AGENT
+import com.lastwave.app.data.lossless.LosslessAudioStream
+import com.lastwave.app.data.lossless.LosslessMusicApi
 import com.lastwave.app.widget.WidgetUpdater
 import kotlinx.coroutines.flow.first
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -119,7 +119,7 @@ data class MusicPlayerState(
     val speed: Float = 1f,
     val bitrateKbps: Int? = null,
     val audioCodec: String? = null,
-    val isQobuz: Boolean = false,
+    val isLossless: Boolean = false,
     val bitDepth: Int? = null,
     val samplingRateKHz: Double? = null,
     val sleepTimerRemainingMs: Long? = null,
@@ -156,7 +156,7 @@ data class PlaybackProgressState(
 class MusicPlayer @Inject constructor(
     @ApplicationContext context: Context,
     private val innerTube: InnerTubeMusicApi,
-    private val qobuzMusicApi: QobuzMusicApi,
+    private val losslessMusicApi: LosslessMusicApi,
     private val settingsPreferences: SettingsPreferences,
     private val discoverRepository: DiscoverRepository,
     private val nativeAudioEngine: dagger.Lazy<NativeAudioEngine>,
@@ -218,7 +218,7 @@ class MusicPlayer @Inject constructor(
     private var bufferingWatchBufferedMs = -1L
     private var bufferingRecoveryCount = 0
     private var bufferingRecoveryJob: Job? = null
-    private val qobuzBypassMediaIds = ConcurrentHashMap.newKeySet<String>()
+    private val losslessBypassMediaIds = ConcurrentHashMap.newKeySet<String>()
     private val resolvingMediaIds = ConcurrentHashMap<String, Long>()
     private val preparedStreams = ConcurrentHashMap<String, ResolvedStream>()
 
@@ -272,7 +272,7 @@ class MusicPlayer @Inject constructor(
             if (mediaItem != null) {
                 if (bufferingWatchMediaId != mediaItem.mediaId) {
                     resetBufferingWatch(mediaItem.mediaId)
-                    qobuzBypassMediaIds.retainAll(setOf(mediaItem.mediaId))
+                    losslessBypassMediaIds.retainAll(setOf(mediaItem.mediaId))
                 }
                 if (retryMediaId != mediaItem.mediaId) {
                     retryMediaId = mediaItem.mediaId
@@ -350,9 +350,9 @@ class MusicPlayer @Inject constructor(
                 ?.customCacheKey
                 ?.let(preparedStreams::get)
             val customCacheKey = player.currentMediaItem?.localConfiguration?.customCacheKey
-            val failedQobuzStream = rejectedStream?.isQobuz
-                ?: customCacheKey?.startsWith("qobuz:")
-                ?: _state.value.isQobuz
+            val failedLosslessStream = rejectedStream?.isLossless
+                ?: customCacheKey?.startsWith("lossless:")
+                ?: _state.value.isLossless
             val rejectedYouTubeCandidate = rejectedStream?.youtubeCandidate
             val videoId = trackVideoId ?: rejectedYouTubeCandidate?.videoId
             val httpStatus = error.httpStatusCodeOrNull()
@@ -372,8 +372,8 @@ class MusicPlayer @Inject constructor(
                 )
             } ?: currentTrack?.let { logResolutionFailure(it, "player-error", errorRetryCount, error) }
 
-            if (failedQobuzStream && failedMediaId != null) {
-                qobuzBypassMediaIds += failedMediaId
+            if (failedLosslessStream && failedMediaId != null) {
+                losslessBypassMediaIds += failedMediaId
             } else if (!videoId.isNullOrBlank()) {
                 if (rejectedYouTubeCandidate == null) innerTube.invalidateCache(videoId)
                 innerTube.reportPlaybackFailure(videoId, rejectedYouTubeCandidate)
@@ -382,10 +382,10 @@ class MusicPlayer @Inject constructor(
             val confirmedWithoutRetry = isExplicitlyUnplayableFailure(error) ||
                 isUnsupportedMediaFailure(error)
             val confirmedAfterRetry = errorRetryCount > 0 && isPermanentHttpFailure(error)
-            // Any Qobuz CDN/format failure gets one immediate YouTube Music
+            // Any Lossless CDN/format failure gets one immediate YouTube Music
             // fallback. Permanent-error skipping applies only after that
             // alternate source has also failed.
-            if ((confirmedWithoutRetry || confirmedAfterRetry) && !failedQobuzStream) {
+            if ((confirmedWithoutRetry || confirmedAfterRetry) && !failedLosslessStream) {
                 _state.update {
                     it.copy(error = "Track unavailable", isPlaying = false, isBuffering = false)
                 }
@@ -413,7 +413,7 @@ class MusicPlayer @Inject constructor(
                         val stream = resolveTrackAudioStream(
                             track = currentTrack,
                             videoId = videoId,
-                            allowQobuz = !failedQobuzStream,
+                            allowLossless = !failedLosslessStream,
                         )
                         val updated = currentTrack.copy(
                             playbackUrl = null,
@@ -772,7 +772,7 @@ class MusicPlayer @Inject constructor(
                     resolveTrackAudioStreamWithRetry(
                         track = selectedTrack,
                         videoId = selectedTrack.videoId,
-                        allowQobuz = selectedTrack.mediaIdKey() !in qobuzBypassMediaIds,
+                        allowLossless = selectedTrack.mediaIdKey() !in losslessBypassMediaIds,
                     )
                 } else {
                     null
@@ -1100,7 +1100,7 @@ class MusicPlayer @Inject constructor(
                 val resolved = resolveTrackAudioStreamWithRetry(
                     track = track,
                     videoId = track.videoId,
-                    allowQobuz = expectedMediaId !in qobuzBypassMediaIds,
+                    allowLossless = expectedMediaId !in losslessBypassMediaIds,
                 )
                 currentCoroutineContext().ensureActive()
                 withContext(Dispatchers.Main.immediate) {
@@ -1468,17 +1468,17 @@ class MusicPlayer @Inject constructor(
             ?.customCacheKey
             ?.let(preparedStreams::get)
         val customCacheKey = player.currentMediaItem?.localConfiguration?.customCacheKey
-        val failedQobuzStream = rejectedStream?.isQobuz
-            ?: customCacheKey?.startsWith("qobuz:")
-            ?: _state.value.isQobuz
+        val failedLosslessStream = rejectedStream?.isLossless
+            ?: customCacheKey?.startsWith("lossless:")
+            ?: _state.value.isLossless
         val candidateVideoId = rejectedStream?.youtubeCandidate?.videoId ?: failedTrack.videoId
-        if (failedQobuzStream) qobuzBypassMediaIds += expectedMediaId
+        if (failedLosslessStream) losslessBypassMediaIds += expectedMediaId
 
         preloadJob?.cancel()
         player.stop()
         bufferingRecoveryJob = applicationScope.launch(Dispatchers.Main.immediate) {
             withContext(Dispatchers.IO) {
-                if (!failedQobuzStream) {
+                if (!failedLosslessStream) {
                     candidateVideoId
                         ?.takeIf(String::isNotBlank)
                         ?.let { innerTube.reportPlaybackFailure(it, rejectedStream?.youtubeCandidate) }
@@ -1492,7 +1492,7 @@ class MusicPlayer @Inject constructor(
                     resolveTrackAudioStream(
                         track = failedTrack,
                         videoId = candidateVideoId,
-                        allowQobuz = !failedQobuzStream,
+                        allowLossless = !failedLosslessStream,
                     )
                 }
                 withContext(Dispatchers.Main.immediate) {
@@ -1526,7 +1526,7 @@ class MusicPlayer @Inject constructor(
         bufferingWatchPositionMs = -1L
         bufferingWatchBufferedMs = -1L
         bufferingRecoveryCount = 0
-        if (mediaId == null) qobuzBypassMediaIds.clear()
+        if (mediaId == null) losslessBypassMediaIds.clear()
     }
 
     @MainThread
@@ -1585,7 +1585,7 @@ class MusicPlayer @Inject constructor(
         val audioCodec: String?,
         val cacheKey: String,
         val requestHeaders: Map<String, String> = emptyMap(),
-        val isQobuz: Boolean = false,
+        val isLossless: Boolean = false,
         val bitDepth: Int? = null,
         val samplingRateKHz: Double? = null,
         val youtubeCandidate: YouTubeAudioStream? = null,
@@ -1594,40 +1594,40 @@ class MusicPlayer @Inject constructor(
     private suspend fun resolveTrackAudioStream(
         track: PlayableTrack,
         videoId: String?,
-        allowQobuz: Boolean = true,
+        allowLossless: Boolean = true,
     ): ResolvedStream = withContext(Dispatchers.IO) {
         val misc = runCatching { settingsPreferences.settings.first() }.getOrDefault(MiscSettings())
-        if (!allowQobuz) return@withContext resolveYoutubeTrackAudioStream(track, videoId)
+        if (!allowLossless) return@withContext resolveYoutubeTrackAudioStream(track, videoId)
 
-        // Resolve both sources together, but always await Qobuz first. If it
+        // Resolve both sources together, but always await lossless first. If it
         // fails or times out, the YouTube result is already being prepared.
         supervisorScope {
-            val qobuzDeferred = async(Dispatchers.IO) {
-                resolveQobuzTrackAudioStream(track, misc)
+            val losslessDeferred = async(Dispatchers.IO) {
+                resolveLosslessTrackAudioStream(track, misc)
             }
             val youtubeDeferred = async(Dispatchers.IO) {
                 resolveYoutubeTrackAudioStream(track, videoId)
             }
             try {
-                qobuzDeferred.await() ?: youtubeDeferred.await()
+                losslessDeferred.await() ?: youtubeDeferred.await()
             } finally {
-                qobuzDeferred.cancel()
+                losslessDeferred.cancel()
                 youtubeDeferred.cancel()
             }
         }
     }
 
-    private suspend fun resolveQobuzTrackAudioStream(
+    private suspend fun resolveLosslessTrackAudioStream(
         track: PlayableTrack,
         misc: MiscSettings,
     ): ResolvedStream? {
-        val qobuzStream = withTimeoutOrNull(QOBUZ_RESOLVE_TIMEOUT_MS) {
+        val losslessStream = withTimeoutOrNull(LOSSLESS_RESOLVE_TIMEOUT_MS) {
             try {
-                qobuzMusicApi.resolveStream(
+                losslessMusicApi.resolveStream(
                     title = track.title,
                     artist = track.artist,
                     expectedAlbum = track.album,
-                    preferredQuality = misc.qobuzQuality,
+                    preferredQuality = misc.losslessQuality,
                 )
             } catch (cancellation: CancellationException) {
                 throw cancellation
@@ -1636,20 +1636,20 @@ class MusicPlayer @Inject constructor(
             }
         } ?: return null
         val codec = when {
-            qobuzStream.bitDepth > 16 || qobuzStream.samplingRate > 48.0 -> "HI-RES FLAC"
-            qobuzStream.formatId == QobuzMusicApi.QUALITY_CD_LOSSLESS -> "LOSSLESS"
-            qobuzStream.formatId == QobuzMusicApi.QUALITY_MP3_320 -> "MP3 320k"
+            losslessStream.bitDepth > 16 || losslessStream.samplingRate > 48.0 -> "HI-RES FLAC"
+            losslessStream.formatId == LosslessMusicApi.QUALITY_CD_LOSSLESS -> "LOSSLESS"
+            losslessStream.formatId == LosslessMusicApi.QUALITY_MP3_320 -> "MP3 320k"
             else -> "LOSSLESS"
         }
         return ResolvedStream(
-            url = qobuzStream.url,
-            mimeType = qobuzStream.mimeType,
-            bitrateKbps = qobuzStream.bitrateKbps,
+            url = losslessStream.url,
+            mimeType = losslessStream.mimeType,
+            bitrateKbps = losslessStream.bitrateKbps,
             audioCodec = codec,
-            cacheKey = "qobuz:${track.mediaIdKey()}:${qobuzStream.formatId}",
-            isQobuz = true,
-            bitDepth = qobuzStream.bitDepth.takeIf { it > 0 },
-            samplingRateKHz = qobuzStream.samplingRate.takeIf { it > 0 },
+            cacheKey = "lossless:${track.mediaIdKey()}:${losslessStream.formatId}",
+            isLossless = true,
+            bitDepth = losslessStream.bitDepth.takeIf { it > 0 },
+            samplingRateKHz = losslessStream.samplingRate.takeIf { it > 0 },
         )
     }
 
@@ -1685,7 +1685,7 @@ class MusicPlayer @Inject constructor(
             audioCodec = codec,
             cacheKey = ytStream.mediaCacheKey,
             requestHeaders = ytStream.requestHeaders,
-            isQobuz = false,
+            isLossless = false,
             samplingRateKHz = ytStream.sampleRateHz?.let { it / 1_000.0 },
             youtubeCandidate = ytStream,
         )
@@ -1696,7 +1696,7 @@ class MusicPlayer @Inject constructor(
             it.copy(
                 bitrateKbps = resolved.bitrateKbps,
                 audioCodec = resolved.audioCodec,
-                isQobuz = resolved.isQobuz,
+                isLossless = resolved.isLossless,
                 bitDepth = resolved.bitDepth,
                 samplingRateKHz = resolved.samplingRateKHz,
             )
@@ -1706,12 +1706,12 @@ class MusicPlayer @Inject constructor(
     private suspend fun resolveTrackAudioStreamWithRetry(
         track: PlayableTrack,
         videoId: String?,
-        allowQobuz: Boolean,
+        allowLossless: Boolean,
     ): ResolvedStream {
         var lastFailure: Throwable? = null
         repeat(2) { attempt ->
             try {
-                return resolveTrackAudioStream(track, videoId, allowQobuz)
+                return resolveTrackAudioStream(track, videoId, allowLossless)
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (error: Throwable) {
@@ -1760,7 +1760,7 @@ class MusicPlayer @Inject constructor(
         PlaybackDiagnostics.event(
             "Stream",
             "stage=$stage videoId=${candidate?.videoId.orEmpty()} " +
-                "client=${candidate?.clientProfile ?: if (stream.isQobuz) "QOBUZ" else "unknown"} " +
+                "client=${candidate?.clientProfile ?: if (stream.isLossless) "LOSSLESS" else "unknown"} " +
                 "itag=${candidate?.itag ?: -1} mime=${stream.mimeType} expiry=$expiry " +
                 "retry=$retry http=${httpStatus ?: 0} error=${error?.javaClass?.simpleName.orEmpty()}",
         )
@@ -1827,7 +1827,7 @@ class MusicPlayer @Inject constructor(
             it.copy(
                 bitrateKbps = trueBitrate,
                 audioCodec = codec,
-                isQobuz = false,
+                isLossless = false,
             )
         }
     }
@@ -1873,7 +1873,7 @@ class MusicPlayer @Inject constructor(
                     bitrateKbps = bitrateKbps,
                     bitDepth = bitDepth ?: if (isFlac) 16 else null,
                     samplingRateKHz = sampleRateKHz ?: if (isFlac) 44.1 else null,
-                    isQobuz = isFlac && (bitDepth ?: 0) > 16,
+                    isLossless = isFlac && (bitDepth ?: 0) > 16,
                 )
             }
         } catch (_: Exception) {
@@ -2047,7 +2047,7 @@ class MusicPlayer @Inject constructor(
             speed = player.playbackParameters.speed,
             bitrateKbps = previous.bitrateKbps.takeIf { sameTrack },
             audioCodec = previous.audioCodec.takeIf { sameTrack },
-            isQobuz = previous.isQobuz && sameTrack,
+            isLossless = previous.isLossless && sameTrack,
             bitDepth = previous.bitDepth.takeIf { sameTrack },
             samplingRateKHz = previous.samplingRateKHz.takeIf { sameTrack },
             sleepTimerRemainingMs = sleepTimerDeadlineMs?.minus(SystemClock.elapsedRealtime())?.coerceAtLeast(0),
@@ -2069,7 +2069,7 @@ class MusicPlayer @Inject constructor(
         const val PLAYBACK_SESSION_KEY = "active_session"
         /** Ticker-driven session persistence cadence (explicit state changes persist immediately). */
         const val TICKER_PERSIST_INTERVAL_MS = 2_000L
-        const val QOBUZ_RESOLVE_TIMEOUT_MS = 4_000L
+        const val LOSSLESS_RESOLVE_TIMEOUT_MS = 4_000L
         const val MAX_PLAYBACK_RETRIES = 2
         const val PLAYBACK_RETRY_BASE_DELAY_MS = 350L
         const val PLAYBACK_RETRY_JITTER_MS = 250L

--- a/app/src/main/java/com/lastwave/app/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/lastwave/app/ui/auth/AuthViewModel.kt
@@ -54,6 +54,13 @@ class AuthViewModel @Inject constructor(
         _webAuthState.value = WebAuthState.AwaitingApproval(authRepository.authUrl())
     }
 
+    /** Skips Last.fm sign-in entirely and drops straight into the app. */
+    fun continueAsGuest() {
+        viewModelScope.launch {
+            authRepository.continueAsGuest()
+        }
+    }
+
     fun signInDirect(username: String) {
         if (username.isBlank()) return
         _webAuthState.value = WebAuthState.CompletingSignIn

--- a/app/src/main/java/com/lastwave/app/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/lastwave/app/ui/auth/LoginScreen.kt
@@ -69,6 +69,7 @@ fun LoginScreen(
     onSignOut: () -> Unit,
     onRestoreBackupAndSignIn: (String) -> Unit,
     onDismissError: () -> Unit,
+    onContinueAsGuest: () -> Unit = {},
 ) {
     val context = LocalContext.current
     var restoreReadError by remember { mutableStateOf<String?>(null) }
@@ -191,6 +192,14 @@ fun LoginScreen(
                                     modifier = Modifier.padding(end = 8.dp),
                                 )
                                 Text("Restore backup & login")
+                            }
+                            Spacer(Modifier.height(12.dp))
+                            TextButton(
+                                onClick = onContinueAsGuest,
+                                enabled = !busy,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text("Continue as guest")
                             }
                             Spacer(Modifier.height(12.dp))
                             Text(

--- a/app/src/main/java/com/lastwave/app/ui/common/TrackDetailsSheet.kt
+++ b/app/src/main/java/com/lastwave/app/ui/common/TrackDetailsSheet.kt
@@ -71,7 +71,7 @@ import com.lastwave.app.data.local.SessionPreferences
 import com.lastwave.app.data.model.RecentTracksEnvelope
 import com.lastwave.app.data.music.InnerTubeMusicApi
 import com.lastwave.app.data.network.LastFmApiService
-import com.lastwave.app.data.qobuz.QobuzMusicApi
+import com.lastwave.app.data.lossless.LosslessMusicApi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -100,8 +100,8 @@ data class TrackSpecs(
     val qualityBadge: String = "Resolving...",
     val audioCodec: String = "Detecting...",
     val bitDepthSampleRate: String = "Analyzing...",
-    val provider: String = "Qobuz / YouTube",
-    val isQobuz: Boolean = false,
+    val provider: String = "Lossless / YouTube",
+    val isLossless: Boolean = false,
     val durationText: String = "--:--",
     val downloadedEntity: DownloadedTrackEntity? = null,
     val isDownloading: Boolean = false,
@@ -115,7 +115,7 @@ data class TrackSpecs(
 
 @HiltViewModel
 class TrackDetailsViewModel @Inject constructor(
-    private val qobuzMusicApi: QobuzMusicApi,
+    private val losslessMusicApi: LosslessMusicApi,
     private val innerTube: InnerTubeMusicApi,
     private val downloadedTrackDao: DownloadedTrackDao,
     private val downloadManager: TrackDownloadManager,
@@ -253,19 +253,19 @@ class TrackDetailsViewModel @Inject constructor(
                 }
 
                 // 3. Audio stream resolution
-                val qobuzStream = runCatching {
-                    qobuzMusicApi.resolveStream(title, artist, preferredQuality = QobuzMusicApi.QUALITY_MAX_HI_RES)
+                val losslessStream = runCatching {
+                    losslessMusicApi.resolveStream(title, artist, preferredQuality = LosslessMusicApi.QUALITY_MAX_HI_RES)
                 }.getOrNull()
 
-                if (qobuzStream != null) {
+                if (losslessStream != null) {
                     val badge = when {
-                        qobuzStream.bitDepth > 16 || qobuzStream.samplingRate > 48.0 -> "24-BIT HI-RES"
-                        qobuzStream.formatId == QobuzMusicApi.QUALITY_CD_LOSSLESS -> "CD LOSSLESS"
-                        qobuzStream.formatId == QobuzMusicApi.QUALITY_MP3_320 -> "320k MP3"
+                        losslessStream.bitDepth > 16 || losslessStream.samplingRate > 48.0 -> "24-BIT HI-RES"
+                        losslessStream.formatId == LosslessMusicApi.QUALITY_CD_LOSSLESS -> "CD LOSSLESS"
+                        losslessStream.formatId == LosslessMusicApi.QUALITY_MP3_320 -> "320k MP3"
                         else -> "FLAC"
                     }
-                    val codec = if (qobuzStream.formatId == QobuzMusicApi.QUALITY_MP3_320) "MPEG Layer 3 (MP3)" else "Free Lossless Audio Codec (FLAC)"
-                    val depthRate = "${qobuzStream.bitDepth}-bit / ${qobuzStream.samplingRate} kHz (${qobuzStream.bitrateKbps ?: 0} kbps)"
+                    val codec = if (losslessStream.formatId == LosslessMusicApi.QUALITY_MP3_320) "MPEG Layer 3 (MP3)" else "Free Lossless Audio Codec (FLAC)"
+                    val depthRate = "${losslessStream.bitDepth}-bit / ${losslessStream.samplingRate} kHz (${losslessStream.bitrateKbps ?: 0} kbps)"
                     val durText = downloaded?.durationMs?.takeIf { it > 0L }?.let { ms ->
                         val dur = (ms / 1000).toInt()
                         "%d:%02d".format(dur / 60, dur % 60)
@@ -275,8 +275,8 @@ class TrackDetailsViewModel @Inject constructor(
                         qualityBadge = badge,
                         audioCodec = codec,
                         bitDepthSampleRate = depthRate,
-                        provider = "Qobuz Lossless Master CDN",
-                        isQobuz = true,
+                        provider = "Lossless Master CDN",
+                        isLossless = true,
                         durationText = durText,
                     )
                 } else {
@@ -295,7 +295,7 @@ class TrackDetailsViewModel @Inject constructor(
                         audioCodec = codec,
                         bitDepthSampleRate = "16-bit / 48.0 kHz ($bitrate)",
                         provider = "YouTube Music CDN",
-                        isQobuz = false,
+                        isLossless = false,
                     )
                 }
             }

--- a/app/src/main/java/com/lastwave/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/lastwave/app/ui/navigation/NavGraph.kt
@@ -149,6 +149,7 @@ fun LastWaveNavHost(
                 onSignOut = authViewModel::signOut,
                 onRestoreBackupAndSignIn = authViewModel::beginRestoreAndSignIn,
                 onDismissError = authViewModel::dismissError,
+                onContinueAsGuest = authViewModel::continueAsGuest,
             )
         }
 

--- a/app/src/main/java/com/lastwave/app/ui/player/PlayerHost.kt
+++ b/app/src/main/java/com/lastwave/app/ui/player/PlayerHost.kt
@@ -2541,14 +2541,14 @@ internal fun formatTime(ms: Long): String {
 }
 
 private fun qualityLabel(state: MusicPlayerState): String = when {
-    // Qobuz with known bit depth / sampling rate → show precise format
-    state.isQobuz && state.bitDepth != null && state.samplingRateKHz != null -> {
+    // Lossless with known bit depth / sampling rate → show precise format
+    state.isLossless && state.bitDepth != null && state.samplingRateKHz != null -> {
         val rate = if (state.samplingRateKHz % 1.0 == 0.0) state.samplingRateKHz.toInt().toString()
         else state.samplingRateKHz.toString()
         "FLAC ${state.bitDepth}/$rate"
     }
-    state.isQobuz && state.audioCodec == "MP3 320k" -> "MP3 320k"
-    state.isQobuz -> state.audioCodec ?: "LOSSLESS"
+    state.isLossless && state.audioCodec == "MP3 320k" -> "MP3 320k"
+    state.isLossless -> state.audioCodec ?: "LOSSLESS"
     // YouTube with known codec + bitrate → e.g. "OPUS 160k" or "AAC 256k"
     state.audioCodec != null && state.bitrateKbps != null -> "${state.audioCodec} ${state.bitrateKbps}k"
     state.audioCodec != null -> state.audioCodec

--- a/app/src/main/java/com/lastwave/app/ui/settings/DownloadsScreen.kt
+++ b/app/src/main/java/com/lastwave/app/ui/settings/DownloadsScreen.kt
@@ -224,7 +224,7 @@ fun DownloadsScreen(
                             fontWeight = FontWeight.Bold,
                         )
                         Text(
-                            "Tap the 3-dot menu on any song and select \"Download (Max Quality)\". Qobuz FLAC tracks and YouTube audio are saved directly to your device's Music/LastWave folder with embedded metadata & synchronized LRCLIB lyrics.",
+                            "Tap the 3-dot menu on any song and select \"Download (Max Quality)\". Lossless FLAC tracks and YouTube audio are saved directly to your device's Music/LastWave folder with embedded metadata & synchronized LRCLIB lyrics.",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center,
@@ -553,13 +553,13 @@ private fun DownloadedTrackCard(
                     Spacer(Modifier.width(6.dp))
                     Surface(
                         shape = RoundedCornerShape(6.dp),
-                        color = if (track.isQobuz) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondaryContainer,
+                        color = if (track.isLossless) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondaryContainer,
                     ) {
                         Text(
                             text = track.formatBadge,
                             style = MaterialTheme.typography.labelSmall,
                             fontWeight = FontWeight.Bold,
-                            color = if (track.isQobuz) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSecondaryContainer,
+                            color = if (track.isLossless) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
                         )
                     }

--- a/app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt
+++ b/app/src/main/java/com/lastwave/app/ui/settings/DownloadsViewModel.kt
@@ -125,21 +125,25 @@ class DownloadsViewModel @Inject constructor(
     }
 
     fun playTrack(track: DownloadedTrackEntity) {
-        val playable = PlayableTrack(
-            title = track.title,
-            artist = track.artist,
-            album = track.album,
-            artworkUrl = track.artworkUrl,
-            playbackUrl = track.mediaStoreUri ?: track.filePath,
-        )
+        val allTracks = downloadedTracks.value
+        val startIndex = allTracks.indexOfFirst { it.id == track.id }.let { if (it >= 0) it else 0 }
+        val queue = (allTracks.ifEmpty { listOf(track) }).map { it.toPlayableTrack() }
         try {
-            musicPlayer.play(playable, sourceLabel = "Downloads")
+            musicPlayer.playQueue(queue, startIndex = startIndex, sourceLabel = "Downloads")
         } catch (error: Exception) {
             android.util.Log.e("DownloadsViewModel", "Could not play download", error)
         } catch (error: LinkageError) {
             android.util.Log.e("DownloadsViewModel", "Playback unsupported on this device", error)
         }
     }
+
+    private fun DownloadedTrackEntity.toPlayableTrack(): PlayableTrack = PlayableTrack(
+        title = title,
+        artist = artist,
+        album = album,
+        artworkUrl = artworkUrl,
+        playbackUrl = mediaStoreUri ?: filePath,
+    )
 
     fun openInFileManager() {
         try {

--- a/app/src/main/java/com/lastwave/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/lastwave/app/ui/settings/SettingsScreen.kt
@@ -622,7 +622,7 @@ fun SettingsScreen(
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     SectionLabel("Audio & Streaming")
-                    val qualitySubtitle = when (misc.qobuzQuality) {
+                    val qualitySubtitle = when (misc.losslessQuality) {
                         27 -> "Max (Up to 24-bit / 192 kHz)"
                         7 -> "Hi-Res (24-bit / 96 kHz)"
                         6 -> "CD Lossless (16-bit / 44.1 kHz FLAC)"
@@ -638,7 +638,7 @@ fun SettingsScreen(
                                 icon = Icons.Filled.HighQuality,
                                 iconContainer = MaterialTheme.colorScheme.primaryContainer,
                                 iconTint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                title = "Qobuz-first Streaming",
+                                title = "Lossless-first Streaming",
                                 subtitle = "$qualitySubtitle \u2022 YouTube Music fallback",
                                 onClick = { showQualityDialog = true },
                                 position = position,
@@ -1096,11 +1096,11 @@ fun SettingsScreen(
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     tiers.forEach { (qualityId, title, meta) ->
                         val (subtitle, badge) = meta
-                        val isSelected = misc.qobuzQuality == qualityId
+                        val isSelected = misc.losslessQuality == qualityId
                         Surface(
                             onClick = {
                                 haptic.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
-                                viewModel.setQobuzQuality(qualityId)
+                                viewModel.setLosslessQuality(qualityId)
                                 showQualityDialog = false
                             },
                             shape = RoundedCornerShape(20.dp),

--- a/app/src/main/java/com/lastwave/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/lastwave/app/ui/settings/SettingsViewModel.kt
@@ -237,8 +237,8 @@ class SettingsViewModel @Inject constructor(
 
     fun setDynamicNowPlaying(enabled: Boolean) = launchSettingsAction("update dynamic theme") { themeRepository.setDynamicNowPlaying(enabled) }
     fun setUseCustomFont(enabled: Boolean) = launchSettingsAction("update the app font") { settingsPreferences.setUseCustomFont(enabled) }
-    fun setPreferQobuzStreaming(enabled: Boolean) = launchSettingsAction("update streaming preference") { settingsPreferences.setPreferQobuzStreaming(enabled) }
-    fun setQobuzQuality(quality: Int) = launchSettingsAction("update streaming quality") { settingsPreferences.setQobuzQuality(quality) }
+    fun setPreferLosslessStreaming(enabled: Boolean) = launchSettingsAction("update streaming preference") { settingsPreferences.setPreferLosslessStreaming(enabled) }
+    fun setLosslessQuality(quality: Int) = launchSettingsAction("update streaming quality") { settingsPreferences.setLosslessQuality(quality) }
     fun setStudioMasterClarity(enabled: Boolean) {
         // Apply immediately; DataStore persists the same state for future engine instances.
         runCatching { audioEngine.get().setStudioMasterClarity(enabled) }


### PR DESCRIPTION
Fixes #21. DecoratedMediaCustomViewStyle with an attached MediaSession causes SystemUI on Android 10/One UI 2.x to render its own media chrome as a second layer on top of the app's custom RemoteViews player. Now version-gated: Android 11+ keeps the session-tagged style as before; Android 10 and below uses DecoratedCustomViewStyle. Also includes a fix for missing Qobuz BuildConfig fields that were breaking the release build.