### PR TITLE
fix: prioritize downloaded tracks for offline playback and fix notifi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,30 @@
   and the in-app widget are unaffected, since they all read from
   `mediaSession` directly rather than this notification's `Style` object.
 
+### Added
+- **Offline playback priority across all screens (Fixes #31).**
+  `MusicPlayer.resolveTrackAudioStream()` now checks the local Room database (`DownloadedTrackDao`) and verifies file presence on disk before attempting remote network resolution (Lossless / YouTube Music / InnerTube). When a track has already been downloaded, LastWave plays the local media file directly without making network calls, enabling seamless offline playback across Home, Search, Playlists, Album, and Artist screens and saving cellular data when online.
+
   Files changed:
-  `app/src/main/java/com/lastwave/app/playback/MusicPlaybackService.kt`
+  `app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt`
+
+- **Download state awareness and duplicate download prevention.**
+  - Added `DownloadedTrackDao.findByTrackKey` and deduplication checks in `TrackDownloadManager.downloadTrack` to prevent duplicate download jobs, redundant network requests, and duplicate files (e.g. `(1).flac`) in MediaStore.
+  - The 3-dot context menu sheet (`TrackContextMenuSheet`) now dynamically reflects the track's status (`Downloaded` with check icon, `Downloading…`, or `Download (Max Quality)`), giving instant visual feedback and preventing accidental re-downloads.
+
+  Files changed:
+  `app/src/main/java/com/lastwave/app/data/local/db/DownloadedTrackDao.kt`
+  `app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt`
+  `app/src/main/java/com/lastwave/app/ui/common/TrackContextMenuSheet.kt`
+
+- **Direct navigation from download notifications to the Downloads screen.**
+  `TrackDownloadManager` now fires pending intents with `ACTION_VIEW_DOWNLOADS` targeting `DownloadsScreen` (`AppRoute.Downloads`). Integrated an `AppRouteNavigator` singleton and `AppRouteNavBridge` into `NavGraph` and `MainActivity` so tapping download notifications opens the Downloads screen directly instead of only bringing the app to the foreground.
+
+  Files changed:
+  `app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt`
+  `app/src/main/java/com/lastwave/app/MainActivity.kt`
+  `app/src/main/java/com/lastwave/app/ui/navigation/AppRouteNavigator.kt`
+  `app/src/main/java/com/lastwave/app/ui/navigation/NavGraph.kt`
 
 ## 2026-09-02 — musaibbhat120605
 

--- a/app/src/main/java/com/lastwave/app/MainActivity.kt
+++ b/app/src/main/java/com/lastwave/app/MainActivity.kt
@@ -34,6 +34,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var linkPlaybackResolver: dagger.Lazy<com.lastwave.app.playback.LinkPlaybackResolver>
 
+    @Inject
+    lateinit var appRouteNavigator: dagger.Lazy<com.lastwave.app.ui.navigation.AppRouteNavigator>
+
     private val notificationPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,6 +48,7 @@ class MainActivity : ComponentActivity() {
         runCatching { lastFmAuthCallback.capture(intent) }
             .onFailure { android.util.Log.e(STARTUP_TAG, "Auth callback ignored during startup", it) }
         handlePlaybackIntent(intent)
+        handleNavigationIntent(intent)
         runCatching {
             splashScreen?.setOnExitAnimationListener { provider ->
                 runCatching {
@@ -152,11 +156,21 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun handleNavigationIntent(intent: Intent?) {
+        if (intent == null) return
+        val isDownloadsTarget = intent.action == com.lastwave.app.data.download.TrackDownloadManager.ACTION_VIEW_DOWNLOADS ||
+            intent.getStringExtra(com.lastwave.app.data.download.TrackDownloadManager.EXTRA_NAVIGATE_TO) == Screen.Downloads.route
+        if (isDownloadsTarget) {
+            runCatching { appRouteNavigator.get().navigateTo(Screen.Downloads.route) }
+        }
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         runCatching { lastFmAuthCallback.capture(intent) }
         handlePlaybackIntent(intent)
+        handleNavigationIntent(intent)
     }
 
     private companion object {

--- a/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
+++ b/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
@@ -75,10 +75,15 @@ class TrackDownloadManager @Inject constructor(
     companion object {
         const val CHANNEL_ID = "lastwave_downloads"
         const val ACTION_CANCEL_DOWNLOAD = "com.lastwave.app.ACTION_CANCEL_DOWNLOAD"
+        const val ACTION_VIEW_DOWNLOADS = "com.lastwave.app.ACTION_VIEW_DOWNLOADS"
         const val EXTRA_DOWNLOAD_KEY = "download_key"
+        const val EXTRA_NAVIGATE_TO = "navigate_to"
         private const val PUBLIC_DIR_NAME = "LastWave"
         private const val DOWNLOAD_BUFFER_SIZE = 512 * 1024 // 512 KB
         private const val MAX_DOWNLOAD_RETRIES = 1
+
+        fun makeDownloadKey(title: String, artist: String): String =
+            "${artist.trim().lowercase()}_${title.trim().lowercase()}"
     }
 
     // Dedicated HTTP client with extended timeouts and high-throughput connection pooling
@@ -141,6 +146,44 @@ class TrackDownloadManager @Inject constructor(
         return activeKeys.contains(key) || (progress != null && !progress.isFinished && progress.error == null)
     }
 
+    suspend fun isTrackDownloaded(title: String, artist: String): Boolean = withContext(Dispatchers.IO) {
+        val key = makeDownloadKey(title, artist)
+        val existing = runCatching {
+            downloadedTrackDao.findByTrackKey(key)
+                ?: downloadedTrackDao.findByTitleAndArtist(title.trim(), artist.trim())
+        }.getOrNull()
+
+        if (existing != null) {
+            val fileStillPresent = when {
+                existing.mediaStoreUri != null -> runCatching {
+                    context.contentResolver.openInputStream(Uri.parse(existing.mediaStoreUri))?.use { }
+                    true
+                }.getOrDefault(false)
+                else -> runCatching {
+                    val f = File(existing.filePath)
+                    f.exists() && f.length() > 0
+                }.getOrDefault(false)
+            }
+            if (fileStillPresent) return@withContext true
+        }
+
+        // Check if file already exists in public Music/LastWave directory
+        val publicDir = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC), PUBLIC_DIR_NAME)
+        if (publicDir.exists() && publicDir.isDirectory) {
+            val sanitizedBase = sanitizeFilename("${artist.trim()} - ${title.trim()}")
+            val candidateExtensions = listOf("flac", "m4a", "opus", "mp3", "webm")
+            if (candidateExtensions.any { ext ->
+                    val f = File(publicDir, "$sanitizedBase.$ext")
+                    f.exists() && f.length() > 0
+                }
+            ) {
+                return@withContext true
+            }
+        }
+
+        false
+    }
+
     fun cancelDownload(key: String) {
         activeKeys.remove(key)
         val job = activeJobs.remove(key)
@@ -170,15 +213,21 @@ class TrackDownloadManager @Inject constructor(
 
         val job = applicationScope.launch(Dispatchers.IO) {
             // Already downloaded? Skip re-downloading entirely rather than
-            // re-fetching the file and inserting a duplicate DB row.
-            val existing = runCatching { downloadedTrackDao.findByTitleAndArtist(title, artist) }.getOrNull()
+            // re-fetching the file and inserting a duplicate DB row or (1).flac file.
+            val existing = runCatching {
+                downloadedTrackDao.findByTrackKey(key)
+                    ?: downloadedTrackDao.findByTitleAndArtist(title.trim(), artist.trim())
+            }.getOrNull()
             if (existing != null) {
                 val fileStillPresent = when {
                     existing.mediaStoreUri != null -> runCatching {
                         context.contentResolver.openInputStream(Uri.parse(existing.mediaStoreUri))?.use { }
                         true
                     }.getOrDefault(false)
-                    else -> runCatching { File(existing.filePath).exists() }.getOrDefault(false)
+                    else -> runCatching {
+                        val f = File(existing.filePath)
+                        f.exists() && f.length() > 0
+                    }.getOrDefault(false)
                 }
                 if (fileStillPresent) {
                     activeKeys.remove(key)
@@ -187,6 +236,18 @@ class TrackDownloadManager @Inject constructor(
                 // Row is stale (file was deleted outside the app) — fall through
                 // and re-download; the unique trackKey index means the insert
                 // below will REPLACE this row instead of duplicating it.
+            } else {
+                val publicDir = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC), PUBLIC_DIR_NAME)
+                if (publicDir.exists() && publicDir.isDirectory) {
+                    val sanitizedBase = sanitizeFilename("${artist.trim()} - ${title.trim()}")
+                    val candidateExtensions = listOf("flac", "m4a", "opus", "mp3", "webm")
+                    val existingFile = candidateExtensions.map { File(publicDir, "$sanitizedBase.$it") }
+                        .firstOrNull { it.exists() && it.length() > 0 }
+                    if (existingFile != null) {
+                        activeKeys.remove(key)
+                        return@launch
+                    }
+                }
             }
             val notifId = key.hashCode()
             updateProgress(DownloadProgress(key = key, title = title, artist = artist, progressPercent = 0))
@@ -689,11 +750,13 @@ class TrackDownloadManager @Inject constructor(
         )
 
         val mainIntent = Intent(context, MainActivity::class.java).apply {
+            action = ACTION_VIEW_DOWNLOADS
+            putExtra(EXTRA_NAVIGATE_TO, "downloads")
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
         val contentPendingIntent = PendingIntent.getActivity(
             context,
-            0,
+            notificationId,
             mainIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0),
         )
@@ -719,11 +782,13 @@ class TrackDownloadManager @Inject constructor(
         badgeText: String,
     ) {
         val mainIntent = Intent(context, MainActivity::class.java).apply {
+            action = ACTION_VIEW_DOWNLOADS
+            putExtra(EXTRA_NAVIGATE_TO, "downloads")
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
         val contentPendingIntent = PendingIntent.getActivity(
             context,
-            0,
+            notificationId,
             mainIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0),
         )
@@ -746,12 +811,25 @@ class TrackDownloadManager @Inject constructor(
         artist: String,
         error: String,
     ) {
+        val mainIntent = Intent(context, MainActivity::class.java).apply {
+            action = ACTION_VIEW_DOWNLOADS
+            putExtra(EXTRA_NAVIGATE_TO, "downloads")
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val contentPendingIntent = PendingIntent.getActivity(
+            context,
+            notificationId,
+            mainIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0),
+        )
+
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.stat_notify_error)
             .setContentTitle("Download Failed")
             .setContentText("\"$title\" by $artist: $error")
             .setOngoing(false)
             .setAutoCancel(true)
+            .setContentIntent(contentPendingIntent)
             .build()
 
         runCatching { notificationManager?.notify(notificationId, notification) }

--- a/app/src/main/java/com/lastwave/app/data/local/db/DownloadedTrackDao.kt
+++ b/app/src/main/java/com/lastwave/app/data/local/db/DownloadedTrackDao.kt
@@ -19,6 +19,9 @@ interface DownloadedTrackDao {
     @Query("SELECT * FROM downloaded_tracks WHERE LOWER(title) = LOWER(:title) AND LOWER(artist) = LOWER(:artist) LIMIT 1")
     suspend fun findByTitleAndArtist(title: String, artist: String): DownloadedTrackEntity?
 
+    @Query("SELECT * FROM downloaded_tracks WHERE trackKey = :trackKey LIMIT 1")
+    suspend fun findByTrackKey(trackKey: String): DownloadedTrackEntity?
+
     @Query("SELECT * FROM downloaded_tracks WHERE id = :id LIMIT 1")
     suspend fun findById(id: Long): DownloadedTrackEntity?
 

--- a/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
+++ b/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -162,6 +163,7 @@ class MusicPlayer @Inject constructor(
     private val nativeAudioEngine: dagger.Lazy<NativeAudioEngine>,
     private val audioEffectsEngine: AudioEffectsEngine,
     private val applicationScope: CoroutineScope,
+    private val downloadedTrackDao: dagger.Lazy<com.lastwave.app.data.local.db.DownloadedTrackDao>,
 ) {
     private val appContext = context.applicationContext
     private val playbackPreferences = appContext.getSharedPreferences(
@@ -1591,11 +1593,103 @@ class MusicPlayer @Inject constructor(
         val youtubeCandidate: YouTubeAudioStream? = null,
     )
 
+    private suspend fun resolveLocalDownloadedAudioStream(track: PlayableTrack): ResolvedStream? {
+        val title = track.title.trim()
+        val artist = track.artist.trim()
+        if (title.isBlank() || artist.isBlank()) return null
+
+        val trackKey = "${artist.lowercase()}_${title.lowercase()}"
+        val downloaded = runCatching {
+            val dao = downloadedTrackDao.get()
+            dao.findByTrackKey(trackKey) ?: dao.findByTitleAndArtist(title, artist)
+        }.getOrNull() ?: return null
+
+        val uriString = downloaded.mediaStoreUri?.takeIf(String::isNotBlank)
+            ?: downloaded.filePath.takeIf(String::isNotBlank)
+            ?: return null
+
+        val isAccessible = when {
+            uriString.startsWith("content://") -> runCatching {
+                appContext.contentResolver.openInputStream(Uri.parse(uriString))?.use { }
+                true
+            }.getOrDefault(false)
+            else -> runCatching {
+                val file = if (uriString.startsWith("file://")) {
+                    File(Uri.parse(uriString).path.orEmpty())
+                } else {
+                    File(uriString)
+                }
+                file.exists() && file.length() > 0
+            }.getOrDefault(false)
+        }
+
+        if (!isAccessible) {
+            // Stale database record; file was deleted externally outside the app
+            runCatching { downloadedTrackDao.get().delete(downloaded) }
+            return null
+        }
+
+        val playbackUri = if (uriString.startsWith("/") && !uriString.startsWith("file://")) {
+            Uri.fromFile(File(uriString)).toString()
+        } else {
+            uriString
+        }
+
+        val mime = when {
+            downloaded.filePath.endsWith(".flac", ignoreCase = true) || downloaded.formatBadge.contains("FLAC") -> "audio/flac"
+            downloaded.filePath.endsWith(".m4a", ignoreCase = true) || downloaded.filePath.endsWith(".mp4", ignoreCase = true) || downloaded.formatBadge.contains("M4A") -> "audio/mp4"
+            downloaded.filePath.endsWith(".opus", ignoreCase = true) || downloaded.formatBadge.contains("OPUS") -> "audio/ogg"
+            downloaded.filePath.endsWith(".mp3", ignoreCase = true) || downloaded.formatBadge.contains("MP3") -> "audio/mpeg"
+            else -> "audio/flac"
+        }
+
+        var bitDepth: Int? = null
+        var samplingRateKHz: Double? = null
+        var bitrateKbps: Int? = downloaded.bitrateKbps
+
+        runCatching {
+            val retriever = android.media.MediaMetadataRetriever()
+            try {
+                if (playbackUri.startsWith("content://")) {
+                    retriever.setDataSource(appContext, Uri.parse(playbackUri))
+                } else {
+                    retriever.setDataSource(playbackUri.removePrefix("file://"))
+                }
+                if (bitrateKbps == null || bitrateKbps == 0) {
+                    bitrateKbps = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toIntOrNull()?.let { it / 1000 }
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    samplingRateKHz = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_SAMPLERATE)?.toDoubleOrNull()?.let { it / 1000.0 }
+                    bitDepth = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_BITS_PER_SAMPLE)?.toIntOrNull()
+                }
+            } finally {
+                retriever.release()
+            }
+        }
+
+        return ResolvedStream(
+            url = playbackUri,
+            mimeType = mime,
+            bitrateKbps = bitrateKbps,
+            audioCodec = downloaded.formatBadge,
+            cacheKey = "local:$trackKey",
+            isLossless = downloaded.isLossless,
+            bitDepth = bitDepth,
+            samplingRateKHz = samplingRateKHz,
+        )
+    }
+
     private suspend fun resolveTrackAudioStream(
         track: PlayableTrack,
         videoId: String?,
         allowLossless: Boolean = true,
     ): ResolvedStream = withContext(Dispatchers.IO) {
+        // Prioritize locally downloaded file if already saved to storage — enables
+        // seamless offline playback across all screens and saves mobile data (Issue #31).
+        resolveLocalDownloadedAudioStream(track)?.let { localStream ->
+            return@withContext localStream
+        }
+
         val misc = runCatching { settingsPreferences.settings.first() }.getOrDefault(MiscSettings())
         if (!allowLossless) return@withContext resolveYoutubeTrackAudioStream(track, videoId)
 

--- a/app/src/main/java/com/lastwave/app/ui/common/TrackContextMenuSheet.kt
+++ b/app/src/main/java/com/lastwave/app/ui/common/TrackContextMenuSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
 import androidx.compose.material.icons.filled.Album
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
@@ -51,6 +52,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -116,10 +118,24 @@ class StartMixMenuViewModel @Inject constructor(private val mixLauncher: MixLaun
     }
 }
 
+enum class TrackDownloadStatus {
+    NOT_DOWNLOADED,
+    DOWNLOADING,
+    DOWNLOADED,
+}
+
 @HiltViewModel
 class DownloadMenuViewModel @Inject constructor(
     private val downloadManager: com.lastwave.app.data.download.TrackDownloadManager,
 ) : ViewModel() {
+    val activeDownloads = downloadManager.downloads
+
+    suspend fun checkStatus(title: String, artist: String): TrackDownloadStatus {
+        if (downloadManager.isDownloading(title, artist)) return TrackDownloadStatus.DOWNLOADING
+        if (downloadManager.isTrackDownloaded(title, artist)) return TrackDownloadStatus.DOWNLOADED
+        return TrackDownloadStatus.NOT_DOWNLOADED
+    }
+
     fun download(title: String, artist: String, album: String? = null, artworkUrl: String? = null) {
         downloadManager.downloadTrack(title, artist, album, artworkUrl)
     }
@@ -232,6 +248,14 @@ fun TrackContextMenuSheet(
     var showDetailsSheet by remember { mutableStateOf(false) }
     var resolvedGenre by remember(target) { mutableStateOf<String?>(null) }
     var resolvingGenre by remember(target) { mutableStateOf(false) }
+    val activeDownloads by downloadViewModel.activeDownloads.collectAsState()
+    var isDownloaded by remember(target) { mutableStateOf(false) }
+
+    LaunchedEffect(target, activeDownloads) {
+        if (target is TrackMenuTarget.Track) {
+            isDownloaded = downloadViewModel.checkStatus(target.name, target.artist) == TrackDownloadStatus.DOWNLOADED
+        }
+    }
 
     LaunchedEffect(target) {
         if (target is TrackMenuTarget.Track) {
@@ -335,10 +359,36 @@ fun TrackContextMenuSheet(
                             }
                         }
                     }
+                    val downloadKey = com.lastwave.app.data.download.TrackDownloadManager.makeDownloadKey(t.name, t.artist)
+                    val isDownloading = activeDownloads[downloadKey]?.let { !it.isFinished } == true
                     add { pos ->
-                        MenuActionRow(Icons.Filled.Download, "Download (Max Quality)", position = pos) {
-                            downloadViewModel.download(t.name, t.artist, playable.album, playable.artworkUrl)
-                            onDismiss()
+                        when {
+                            isDownloaded -> {
+                                MenuActionRow(Icons.Filled.CheckCircle, "Downloaded", position = pos) {
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        "Track is already downloaded",
+                                        android.widget.Toast.LENGTH_SHORT,
+                                    ).show()
+                                    onDismiss()
+                                }
+                            }
+                            isDownloading -> {
+                                MenuActionRow(Icons.Filled.Download, "Downloading\u2026", position = pos) {
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        "Download is in progress",
+                                        android.widget.Toast.LENGTH_SHORT,
+                                    ).show()
+                                    onDismiss()
+                                }
+                            }
+                            else -> {
+                                MenuActionRow(Icons.Filled.Download, "Download (Max Quality)", position = pos) {
+                                    downloadViewModel.download(t.name, t.artist, playable.album, playable.artworkUrl)
+                                    onDismiss()
+                                }
+                            }
                         }
                     }
                     add { pos -> MenuActionRow(Icons.Filled.QueuePlayNext, "Play next", position = pos) { musicPlayer.playNext(playable); onDismiss() } }

--- a/app/src/main/java/com/lastwave/app/ui/navigation/AppRouteNavigator.kt
+++ b/app/src/main/java/com/lastwave/app/ui/navigation/AppRouteNavigator.kt
@@ -1,0 +1,29 @@
+package com.lastwave.app.ui.navigation
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Singleton navigation coordinator allowing external components (notifications,
+ * system intents, shortcuts) to trigger navigation to app destinations.
+ */
+@Singleton
+class AppRouteNavigator @Inject constructor() {
+    private val _pendingRoute = MutableStateFlow<String?>(null)
+    val pendingRoute: StateFlow<String?> = _pendingRoute.asStateFlow()
+
+    fun navigateTo(route: String) {
+        if (route.isNotBlank()) {
+            _pendingRoute.value = route
+        }
+    }
+
+    fun consumeRoute(): String? {
+        val route = _pendingRoute.value
+        _pendingRoute.value = null
+        return route
+    }
+}

--- a/app/src/main/java/com/lastwave/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/lastwave/app/ui/navigation/NavGraph.kt
@@ -51,10 +51,25 @@ class GenreExplorerNavBridge @Inject constructor(genreExplorer: GenreExplorer) :
 @HiltViewModel
 class ArtistAlbumNavBridge @Inject constructor(val navigator: ArtistAlbumNavigator) : androidx.lifecycle.ViewModel()
 
+@HiltViewModel
+class AppRouteNavBridge @Inject constructor(val routeNavigator: AppRouteNavigator) : androidx.lifecycle.ViewModel()
+
 @Composable
 fun LastWaveNavHost(
     navController: NavHostController = rememberNavController(),
 ) {
+    val appRouteBridge: AppRouteNavBridge = hiltViewModel()
+    val pendingAppRoute by appRouteBridge.routeNavigator.pendingRoute.collectAsStateWithLifecycle()
+    LaunchedEffect(pendingAppRoute) {
+        val route = pendingAppRoute
+        if (route != null) {
+            appRouteBridge.routeNavigator.consumeRoute()
+            navController.navigate(route) {
+                launchSingleTop = true
+            }
+        }
+    }
+
     // "Explore this genre" from any track's context menu, anywhere in the
     // app — Home, Discover, Playlist, Search — routes here since Genres
     // is a pushed destination on THIS nav controller and none of those


### PR DESCRIPTION
Summary of Changes

Closes #31

This pull request addresses issue #31 ("using download music") and improves download management and notification routing:

1. Offline Playback Prioritization across all screens (Fixes #31):
   - In `MusicPlayer.resolveTrackAudioStream()`, LastWave now checks the local Room database (`DownloadedTrackDao`) and verifies file accessibility on disk before resolving remote streams (Lossless API, InnerTube, YouTube Music).
   - When a track is already downloaded, it immediately plays the local media file directly without network calls. This enables offline playback from Search, Playlists, Album, Artist, and Home screens without "Unable to resolve audio" errors, and saves cellular data when online.
   - Preserves high-res audio badge parameters (FLAC/M4A/OPUS/MP3/WEBM, sample rate, bit depth, bitrate) extracted via `MediaMetadataRetriever`.
   - Automatically cleans up stale database records if a file was deleted externally, falling back gracefully to remote streaming.

2. Download Deduplication & Stale Detection:
   - Added `findByTrackKey` to `DownloadedTrackDao` to query by the indexed unique track key (`${artist}_${title}`).
   - Enhanced `TrackDownloadManager.downloadTrack` deduplication to prevent duplicate jobs, redundant network downloads, and duplicate MediaStore files (e.g. `(1).flac`).

3. Live Download Status in 3-Dot Context Menu:
   - Updated `TrackContextMenuSheet` to observe active downloads and Room status:
     - Downloaded: Shows checkmark icon (`Icons.Filled.CheckCircle`) with "Downloaded" label; tapping notifies the user that the track is already downloaded.
     - Downloading…: Shows downloading indicator while in progress to prevent duplicate clicks.
     - Download (Max Quality): Default download action when not downloaded.

4. **Notification Redirection to Downloads Screen:
   - Download notifications (in-progress, completed, failed) now send pending intents with `ACTION_VIEW_DOWNLOADS`.
   - Added `AppRouteNavigator` singleton and `AppRouteNavBridge` in `NavGraph` and `MainActivity` to navigate directly to `DownloadsScreen` when tapping a download notification.

5. Changelog:
   - Updated `CHANGELOG.md` under `## Unreleased` matching the repository style.