### PR TITLE
feat(ui): smooth 90Hz tab navigation, sleek circular sliders, infinite autoplay, and in-app updater

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,6 +175,17 @@ android {
         cmake {
             path = file("src/main/cpp/CMakeLists.txt")
             version = "3.22.1"
+            // libsoxr 0.1.3's own CMake passes unquoted paths to
+            // cmake_dependent_option, so a space anywhere in the CMake binary
+            // directory breaks configuration. The default binary dir is
+            // <project>/.cxx, so when the checkout itself sits in a path with a
+            // space ("...\Wave app\"), stage the native build somewhere safe.
+            if (rootDir.absolutePath.contains(' ')) {
+                buildStagingDirectory = File(
+                    System.getProperty("java.io.tmpdir"),
+                    "lastwave-cxx",
+                )
+            }
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
         android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <!-- Android 13+ replacement for READ_EXTERNAL_STORAGE. Lets the local
+         library index the music the user already has on the device. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
         android:name=".LastWaveApplication"

--- a/app/src/main/java/com/lastwave/app/MainActivity.kt
+++ b/app/src/main/java/com/lastwave/app/MainActivity.kt
@@ -38,6 +38,11 @@ class MainActivity : androidx.fragment.app.FragmentActivity() {
 
     private val notificationPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
 
+    /** Read access to the device's own music, so the local library can index
+     *  songs the user already has rather than only LastWave's downloads. */
+    private val audioLibraryPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         // Must be called before super.onCreate() and before setContent().
         val splashScreen = runCatching { installSplashScreen() }
@@ -82,6 +87,16 @@ class MainActivity : androidx.fragment.app.FragmentActivity() {
         ) {
             runCatching { notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS) }
                 .onFailure { android.util.Log.w(STARTUP_TAG, "Notification permission request skipped", it) }
+        }
+
+        val audioPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_AUDIO
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+        if (checkSelfPermission(audioPermission) != PackageManager.PERMISSION_GRANTED) {
+            runCatching { audioLibraryPermission.launch(audioPermission) }
+                .onFailure { android.util.Log.w(STARTUP_TAG, "Audio library permission request skipped", it) }
         }
 
         setContent {

--- a/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
+++ b/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
@@ -141,9 +141,25 @@ class TrackDownloadManager @Inject constructor(
         private const val DOWNLOAD_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
         private val CONTENT_RANGE_PATTERN = Regex("""bytes\s+(\d+)-(\d+)/(\d+)""", RegexOption.IGNORE_CASE)
+        private const val MAX_DOWNLOAD_RETRIES = 1
+        /** Device-wide scanning floor. Keeps voice memos, message tones and
+         *  other stray short clips out of the music library. */
+        private const val MIN_LIBRARY_TRACK_MS = 30_000L
+        private const val MEDIASTORE_UNKNOWN = "<unknown>"
 
         fun makeDownloadKey(title: String, artist: String): String =
             "${artist.trim().lowercase()}_${title.trim().lowercase()}"
+    }
+
+    /** Whether the user has granted the read-audio permission this scan needs. */
+    private fun hasAudioReadPermission(): Boolean {
+        val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            android.Manifest.permission.READ_MEDIA_AUDIO
+        } else {
+            android.Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+        return androidx.core.content.ContextCompat.checkSelfPermission(context, permission) ==
+            android.content.pm.PackageManager.PERMISSION_GRANTED
     }
 
     // Dedicated HTTP client with extended timeouts and high-throughput connection pooling
@@ -1482,13 +1498,42 @@ class TrackDownloadManager @Inject constructor(
     }
 
 
-    suspend fun deleteDownloadedTrack(track: DownloadedTrackEntity) = withContext(Dispatchers.IO) {
-        downloadedTrackDao.delete(track)
-        // Delete physical audio file
+    /**
+     * True only for files this app downloaded into Music/LastWave.
+     *
+     * The local library also indexes the user's own music from anywhere on the
+     * device (see [syncDownloadsFromStorage]). Those files are borrowed, not
+     * owned — removing them from the library must never delete them from the
+     * phone, so every deletion path checks this first.
+     */
+    private fun isAppOwned(track: DownloadedTrackEntity): Boolean {
+        val ownedSegment = "${Environment.DIRECTORY_MUSIC}/$PUBLIC_DIR_NAME"
+        if (track.filePath.isNotBlank() && !track.filePath.startsWith("content://")) {
+            return track.filePath.replace('\\', '/').contains(ownedSegment)
+        }
+        val uri = track.mediaStoreUri?.takeIf { it.isNotBlank() } ?: return false
+        return runCatching {
+            context.contentResolver.query(
+                Uri.parse(uri),
+                arrayOf(MediaStore.Audio.Media.RELATIVE_PATH),
+                null,
+                null,
+                null,
+            )?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use false
+                val path = cursor.getString(0).orEmpty()
+                path.startsWith(ownedSegment, ignoreCase = true)
+            } ?: false
+        }.getOrDefault(false)
+    }
+
+    /** Removes the physical file only when this app put it there. */
+    private fun deletePhysicalCopy(track: DownloadedTrackEntity) {
+        if (!isAppOwned(track)) return
         if (!track.mediaStoreUri.isNullOrBlank()) {
             runCatching { context.contentResolver.delete(Uri.parse(track.mediaStoreUri), null, null) }
         }
-        if (track.filePath.isNotBlank()) {
+        if (track.filePath.isNotBlank() && !track.filePath.startsWith("content://")) {
             runCatching {
                 val f = File(track.filePath)
                 if (f.exists()) f.delete()
@@ -1507,29 +1552,13 @@ class TrackDownloadManager @Inject constructor(
         }
     }
 
+    suspend fun deleteDownloadedTrack(track: DownloadedTrackEntity) = withContext(Dispatchers.IO) {
+        downloadedTrackDao.delete(track)
+        deletePhysicalCopy(track)
+    }
+
     suspend fun clearAllDownloads() = withContext(Dispatchers.IO) {
-        val all = downloadedTrackDao.getAllList()
-        all.forEach { track ->
-            if (!track.mediaStoreUri.isNullOrBlank()) {
-                runCatching { context.contentResolver.delete(Uri.parse(track.mediaStoreUri), null, null) }
-            }
-            if (track.filePath.isNotBlank()) {
-                runCatching {
-                    val f = File(track.filePath)
-                    if (f.exists()) f.delete()
-                }
-            }
-            if (!track.lrcFilePath.isNullOrBlank()) {
-                if (track.lrcFilePath.startsWith("content://")) {
-                    runCatching { context.contentResolver.delete(Uri.parse(track.lrcFilePath), null, null) }
-                } else {
-                    runCatching {
-                        val lf = File(track.lrcFilePath)
-                        if (lf.exists()) lf.delete()
-                    }
-                }
-            }
-        }
+        downloadedTrackDao.getAllList().forEach(::deletePhysicalCopy)
         downloadedTrackDao.clearAll()
     }
 
@@ -1624,8 +1653,22 @@ class TrackDownloadManager @Inject constructor(
                 MediaStore.Audio.Media.RELATIVE_PATH,
                 MediaStore.Audio.Media.DATE_ADDED,
             )
-            val selection = "${MediaStore.Audio.Media.RELATIVE_PATH} LIKE ?"
-            val selectionArgs = arrayOf("Music/$PUBLIC_DIR_NAME%")
+            // With full-device scanning on, take every real music file on the
+            // phone (IS_MUSIC already excludes ringtones, alarms and
+            // notifications); otherwise stay inside the app's own folder.
+            val scanWholeDevice = runCatching {
+                settingsPreferences.settings.first().scanFullDeviceAudio
+            }.getOrDefault(true) && hasAudioReadPermission()
+
+            val selection: String
+            val selectionArgs: Array<String>
+            if (scanWholeDevice) {
+                selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0 AND ${MediaStore.Audio.Media.DURATION} > ?"
+                selectionArgs = arrayOf(MIN_LIBRARY_TRACK_MS.toString())
+            } else {
+                selection = "${MediaStore.Audio.Media.RELATIVE_PATH} LIKE ?"
+                selectionArgs = arrayOf("${Environment.DIRECTORY_MUSIC}/$PUBLIC_DIR_NAME%")
+            }
 
             runCatching {
                 context.contentResolver.query(
@@ -1649,8 +1692,14 @@ class TrackDownloadManager @Inject constructor(
                         val uri = Uri.withAppendedPath(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, id.toString())
                         if (uri.toString() in existingUris) continue
 
-                        val title = cursor.getString(titleCol) ?: "Unknown Track"
-                        val artist = cursor.getString(artistCol) ?: "Unknown Artist"
+                        // MediaStore writes the literal "<unknown>" for
+                        // untagged files rather than leaving the column null.
+                        val title = cursor.getString(titleCol)
+                            ?.takeUnless { it.isBlank() || it == MEDIASTORE_UNKNOWN }
+                            ?: "Unknown Track"
+                        val artist = cursor.getString(artistCol)
+                            ?.takeUnless { it.isBlank() || it == MEDIASTORE_UNKNOWN }
+                            ?: "Unknown Artist"
                         val trackKey = makeDownloadKey(title, artist)
                         if (trackKey in existingKeys) continue
 

--- a/app/src/main/java/com/lastwave/app/data/local/SettingsPreferences.kt
+++ b/app/src/main/java/com/lastwave/app/data/local/SettingsPreferences.kt
@@ -80,6 +80,13 @@ data class MiscSettings(
     val wavySeekbarEnabled: Boolean = true,
     /** When true (default), downloads fetch and save synced lyrics (.lrc companion files and embedded tags). */
     val downloadLyrics: Boolean = true,
+    /** YouTube-Music-style endless playback: when a finite queue runs out, keep
+     *  going with tracks similar to what just played instead of stopping. */
+    val autoplayEnabled: Boolean = true,
+    /** Include every audio file on the device in the local library, not just
+     *  the app's own Music/LastWave downloads folder. Imported device files are
+     *  never deleted by the app — see TrackDownloadManager.isAppOwned. */
+    val scanFullDeviceAudio: Boolean = true,
 )
 
 /** Small dedicated prefs object for settings that don't fit ThemePreferences
@@ -103,6 +110,8 @@ class SettingsPreferences @Inject constructor(
         val CROSSFADE_SECONDS = intPreferencesKey("lw_crossfade_seconds")
         val WAVY_SEEKBAR_ENABLED = booleanPreferencesKey("lw_wavy_seekbar_enabled")
         val DOWNLOAD_LYRICS = booleanPreferencesKey("lw_download_lyrics")
+        val AUTOPLAY_ENABLED = booleanPreferencesKey("lw_autoplay_enabled")
+        val SCAN_FULL_DEVICE_AUDIO = booleanPreferencesKey("lw_scan_full_device_audio")
     }
 
     val settings: Flow<MiscSettings> = dataStore.data
@@ -123,6 +132,8 @@ class SettingsPreferences @Inject constructor(
                 crossfadeSeconds = (p.readSafely(Keys.CROSSFADE_SECONDS) ?: 5).coerceIn(1, 12),
                 wavySeekbarEnabled = p.readSafely(Keys.WAVY_SEEKBAR_ENABLED) ?: true,
                 downloadLyrics = p.readSafely(Keys.DOWNLOAD_LYRICS) ?: true,
+                autoplayEnabled = p.readSafely(Keys.AUTOPLAY_ENABLED) ?: true,
+                scanFullDeviceAudio = p.readSafely(Keys.SCAN_FULL_DEVICE_AUDIO) ?: true,
             )
         }
 
@@ -184,6 +195,14 @@ class SettingsPreferences @Inject constructor(
 
     suspend fun setDownloadLyrics(enabled: Boolean) {
         dataStore.edit { it[Keys.DOWNLOAD_LYRICS] = enabled }
+    }
+
+    suspend fun setAutoplayEnabled(enabled: Boolean) {
+        dataStore.edit { it[Keys.AUTOPLAY_ENABLED] = enabled }
+    }
+
+    suspend fun setScanFullDeviceAudio(enabled: Boolean) {
+        dataStore.edit { it[Keys.SCAN_FULL_DEVICE_AUDIO] = enabled }
     }
 
     suspend fun toggleFriendPinned(username: String) {

--- a/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
+++ b/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
@@ -169,6 +169,7 @@ class MusicPlayer @Inject constructor(
     private val settingsPreferences: SettingsPreferences,
     private val equalizerPreferences: EqualizerPreferences,
     private val discoverRepository: DiscoverRepository,
+    private val generateRepository: com.lastwave.app.data.generate.GenerateRepository,
     private val nativeAudioEngine: dagger.Lazy<NativeAudioEngine>,
     private val audioEffectsEngine: AudioEffectsEngine,
     private val applicationScope: CoroutineScope,
@@ -270,6 +271,13 @@ class MusicPlayer @Inject constructor(
     private var radioQueueLoadJob: Job? = null
     private var radioQueueActive = false
     private val radioUsedSeeds = ConcurrentHashMap.newKeySet<String>()
+    private var autoplayLoadJob: Job? = null
+    @Volatile
+    private var autoplayEnabled = true
+    /** Seeds already used for an autoplay refill, so a stalled queue does not
+     *  ask Last.fm for the same similar-tracks list over and over. Touched from
+     *  the refill coroutine and from playback callbacks, so it is concurrent. */
+    private val autoplaySeedsUsed = ConcurrentHashMap.newKeySet<String>()
     private var unavailableSkipJob: Job? = null
     private val unavailableMediaIds = mutableSetOf<String>()
     private var sleepTimerDeadlineMs: Long? = null
@@ -345,6 +353,19 @@ class MusicPlayer @Inject constructor(
         override fun onEvents(player: Player, events: Player.Events) {
             if (player === this@MusicPlayer.player) refresh(player)
         }
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            // Last resort for endless playback: the queue actually ran dry
+            // before a proactive refill landed. Seed from what just played and
+            // resume as soon as tracks arrive.
+            if (playbackState == Player.STATE_ENDED) {
+                val last = _state.value.current ?: return
+                extendAutoplayQueueIfNeeded(
+                    currentIndex = player.currentMediaItemIndex,
+                    seed = last,
+                    resumeWhenLoaded = true,
+                )
+            }
+        }
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             outgoingPlayer?.playWhenReady = isPlaying
             if (isPlaying) {
@@ -404,6 +425,7 @@ class MusicPlayer @Inject constructor(
                 enrichUpcomingQueue(currentIndex)
                 extendDiscoverQueueIfNeeded(currentIndex)
                 extendRadioQueueIfNeeded(currentIndex)
+                extendAutoplayQueueIfNeeded(currentIndex, currentTrack)
                 val nextIndex = if (player.shuffleModeEnabled) {
                     player.nextMediaItemIndex
                 } else {
@@ -783,6 +805,7 @@ class MusicPlayer @Inject constructor(
 
         applicationScope.launch {
             settingsPreferences.settings.collect { settings ->
+                autoplayEnabled = settings.autoplayEnabled
                 crossfadeEnabled = settings.crossfadeEnabled
                 crossfadeDurationMs = settings.crossfadeSeconds.coerceIn(1, 12) * 1000L
                 bitPerfectEnabled = settings.isBitPerfectEnabled
@@ -1830,6 +1853,74 @@ class MusicPlayer @Inject constructor(
         radioUsedSeeds.clear()
     }
 
+    /**
+     * YouTube-Music-style endless playback for ordinary (non-Discover) queues:
+     * as a playlist or album nears its end, quietly extend it with tracks
+     * similar to what is playing so music never just stops.
+     *
+     * Discover queues are skipped — [extendDiscoverQueueIfNeeded] already owns
+     * those — and so are looping queues, which never run out by definition.
+     */
+    private fun extendAutoplayQueueIfNeeded(
+        currentIndex: Int,
+        seed: PlayableTrack?,
+        resumeWhenLoaded: Boolean = false,
+    ) {
+        if (!autoplayEnabled || discoverQueueActive || autoplayLoadJob?.isActive == true) return
+        if (seed == null || seed.title.isBlank() || seed.artist.isBlank()) return
+
+        autoplayLoadJob = applicationScope.launch {
+            try {
+                val shouldLoad = withContext(Dispatchers.Main.immediate) {
+                    if (player.repeatMode != Player.REPEAT_MODE_OFF) return@withContext false
+                    if (player.mediaItemCount == 0) return@withContext false
+                    val remaining = player.mediaItemCount - currentIndex - 1
+                    resumeWhenLoaded || (currentIndex >= 0 && remaining <= AUTOPLAY_REFILL_THRESHOLD)
+                }
+                if (!shouldLoad) return@launch
+
+                val seedKey = seed.queueKey()
+                if (!resumeWhenLoaded && !autoplaySeedsUsed.add(seedKey)) return@launch
+                if (autoplaySeedsUsed.size > AUTOPLAY_SEED_MEMORY) autoplaySeedsUsed.clear()
+
+                // Last.fm similar-tracks is the closest match to the seed; the
+                // taste-based Discover engine covers songs it has never heard of.
+                val similar = runCatching {
+                    generateRepository
+                        .fetchSimilarTracks(seed.title, seed.artist, AUTOPLAY_BATCH_SIZE)
+                        .map(GeneratedTrack::toPlayableTrack)
+                }.onFailure { error ->
+                    android.util.Log.d("MusicPlayer", "Autoplay similar-tracks miss", error)
+                }.getOrDefault(emptyList())
+
+                val batch = similar.ifEmpty {
+                    runCatching {
+                        discoverRepository.nextBatch(AUTOPLAY_BATCH_SIZE).map(GeneratedTrack::toPlayableTrack)
+                    }.onFailure { error ->
+                        android.util.Log.d("MusicPlayer", "Autoplay discover fallback failed", error)
+                    }.getOrDefault(emptyList())
+                }
+                if (batch.isEmpty()) return@launch
+
+                appendMissingDiscoverTracks(batch)
+
+                if (resumeWhenLoaded) {
+                    onMain {
+                        if (player.playbackState == Player.STATE_ENDED &&
+                            player.hasNextMediaItem()
+                        ) {
+                            player.seekToNextMediaItem()
+                            player.prepare()
+                            player.play()
+                        }
+                    }
+                }
+            } finally {
+                autoplayLoadJob = null
+            }
+        }
+    }
+
     private fun isDisallowedRadioTitle(titleLower: String): Boolean {
         val keywords = listOf(
             "mashup", "mash up", "mash-up",
@@ -2850,6 +2941,13 @@ class MusicPlayer @Inject constructor(
         const val DISCOVER_QUEUE_REFILL_THRESHOLD = 8
         const val RADIO_QUEUE_BATCH_SIZE = 25
         const val RADIO_QUEUE_REFILL_THRESHOLD = 6
+        /** How many similar tracks one autoplay refill adds. */
+        const val AUTOPLAY_BATCH_SIZE = 12
+        /** Start refilling once this few tracks remain after the current one. */
+        const val AUTOPLAY_REFILL_THRESHOLD = 2
+        /** Seed keys remembered before the "already used" set is recycled. */
+        const val AUTOPLAY_SEED_MEMORY = 200
+        const val UNAVAILABLE_SKIP_DELAY_MS = 1_000L
         const val POSITION_PERSIST_INTERVAL_MS = 5_000L
         const val MAX_PERSISTED_QUEUE_SIZE = 200
         const val RESTORED_PREVIOUS_TRACKS = 50

--- a/app/src/main/java/com/lastwave/app/ui/common/ExpressiveSlider.kt
+++ b/app/src/main/java/com/lastwave/app/ui/common/ExpressiveSlider.kt
@@ -1,0 +1,174 @@
+package com.lastwave.app.ui.common
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * One shared slider look for the whole app: a sleek circular knob riding a
+ * short rounded capsule track, instead of Material 3's tall vertical thumb.
+ *
+ * The knob is drawn as three concentric circles — a soft accent halo that
+ * grows while the finger is down, the solid accent body, and a small surface
+ * "core" that keeps it legible against a matching-colored track.
+ */
+object ExpressiveSliderDefaults {
+    val ThumbRadius: Dp = 9.dp
+    val TrackHeight: Dp = 6.dp
+
+    /** Box the thumb is measured in. The halo has to fit inside it, and the
+     *  slider derives its horizontal inset from this width. */
+    val ThumbBox: Dp = 26.dp
+}
+
+/** The shared circular knob. Reused by every slider in the app. */
+@Composable
+fun ExpressiveSliderThumb(
+    interactionSource: MutableInteractionSource,
+    enabled: Boolean = true,
+    color: Color = MaterialTheme.colorScheme.primary,
+    coreColor: Color = MaterialTheme.colorScheme.surface,
+    radius: Dp = ExpressiveSliderDefaults.ThumbRadius,
+) {
+    val pressed by interactionSource.collectIsPressedAsState()
+    val dragged by interactionSource.collectIsDraggedAsState()
+    val active = pressed || dragged
+    val halo by animateFloatAsState(
+        targetValue = if (active) 1f else 0.45f,
+        animationSpec = ExpressiveMotion.smoothSpring(),
+        label = "sliderThumbHalo",
+    )
+    val knob = if (enabled) color else color.copy(alpha = 0.38f)
+
+    Box(
+        modifier = Modifier.size(ExpressiveSliderDefaults.ThumbBox),
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(Modifier.size(ExpressiveSliderDefaults.ThumbBox)) {
+            val center = Offset(size.width / 2f, size.height / 2f)
+            val bodyRadius = radius.toPx()
+            drawCircle(
+                color = knob.copy(alpha = 0.22f),
+                radius = bodyRadius + (4.dp.toPx() * halo),
+                center = center,
+            )
+            drawCircle(color = knob, radius = bodyRadius, center = center)
+            drawCircle(color = coreColor, radius = bodyRadius * 0.36f, center = center)
+        }
+    }
+}
+
+/** The shared capsule track, with clearance either side of the knob. */
+@Composable
+fun ExpressiveSliderTrack(
+    fraction: Float,
+    enabled: Boolean = true,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    inactiveColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.20f),
+    height: Dp = ExpressiveSliderDefaults.TrackHeight,
+) {
+    val active = if (enabled) activeColor else activeColor.copy(alpha = 0.38f)
+    val inactive = if (enabled) inactiveColor else inactiveColor.copy(alpha = 0.5f)
+    Canvas(
+        Modifier
+            .fillMaxWidth()
+            .height(ExpressiveSliderDefaults.ThumbBox),
+    ) {
+        val h = height.toPx()
+        val top = (size.height - h) / 2f
+        val corner = CornerRadius(h / 2f, h / 2f)
+        val split = (size.width * fraction.coerceIn(0f, 1f))
+        drawRoundRect(
+            color = inactive,
+            topLeft = Offset(0f, top),
+            size = Size(size.width, h),
+            cornerRadius = corner,
+        )
+        if (split > 0f) {
+            drawRoundRect(
+                color = active,
+                topLeft = Offset(0f, top),
+                size = Size(split, h),
+                cornerRadius = corner,
+            )
+        }
+    }
+}
+
+/**
+ * Drop-in replacement for Material 3's [Slider] wearing the app's circular
+ * knob. Same parameter names as the Material slider so call sites read the
+ * same way.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExpressiveSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onValueChangeFinished: (() -> Unit)? = null,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    steps: Int = 0,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    inactiveColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.20f),
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val span = (valueRange.endInclusive - valueRange.start).takeIf { it > 0f } ?: 1f
+    val fraction = ((value - valueRange.start) / span).coerceIn(0f, 1f)
+
+    Slider(
+        value = value,
+        onValueChange = onValueChange,
+        onValueChangeFinished = onValueChangeFinished,
+        valueRange = valueRange,
+        steps = steps,
+        enabled = enabled,
+        modifier = modifier,
+        interactionSource = interactionSource,
+        colors = SliderDefaults.colors(
+            // Every visible pixel is drawn by the slots below; the Material
+            // colors only still exist so ticks stay invisible.
+            activeTickColor = Color.Transparent,
+            inactiveTickColor = Color.Transparent,
+            disabledActiveTickColor = Color.Transparent,
+            disabledInactiveTickColor = Color.Transparent,
+        ),
+        thumb = {
+            ExpressiveSliderThumb(
+                interactionSource = interactionSource,
+                enabled = enabled,
+                color = activeColor,
+            )
+        },
+        track = {
+            ExpressiveSliderTrack(
+                fraction = fraction,
+                enabled = enabled,
+                activeColor = activeColor,
+                inactiveColor = inactiveColor,
+            )
+        },
+    )
+}

--- a/app/src/main/java/com/lastwave/app/ui/generate/GenerateScreen.kt
+++ b/app/src/main/java/com/lastwave/app/ui/generate/GenerateScreen.kt
@@ -48,8 +48,8 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import com.lastwave.app.ui.common.ExpressiveSlider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -203,7 +203,7 @@ fun GenerateScreen(
                                     )
                                 } else {
                                     Text("Track count: ${state.trackCount}", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Medium)
-                                    Slider(
+                                    ExpressiveSlider(
                                         value = state.trackCount.toFloat(),
                                         onValueChange = { viewModel.setTrackCount(it.toInt()) },
                                         valueRange = 5f..35f,

--- a/app/src/main/java/com/lastwave/app/ui/player/PlayerHost.kt
+++ b/app/src/main/java/com/lastwave/app/ui/player/PlayerHost.kt
@@ -76,6 +76,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AllInclusive
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteOutline
@@ -111,6 +112,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -190,6 +192,7 @@ import com.lastwave.app.playback.PlayableTrack
 import com.lastwave.app.ui.common.ArtworkImage
 import com.lastwave.app.ui.common.ExpressiveInlineLoadingIndicator
 import com.lastwave.app.ui.common.ExpressiveMotion
+import com.lastwave.app.ui.common.ExpressiveSlider
 import com.lastwave.app.ui.common.PlaylistCover
 import com.lastwave.app.ui.common.TrackContextMenuSheet
 import com.lastwave.app.ui.common.TrackMenuCapabilities
@@ -315,6 +318,10 @@ class PlayerViewModel @Inject constructor(
         if (customPlaylistsLoaded) return
         customPlaylistsLoaded = true
         viewModelScope.launch { refreshCustomPlaylists() }
+    }
+
+    fun setAutoplayEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsPreferences.setAutoplayEnabled(enabled) }
     }
 
     fun loadLyrics(track: PlayableTrack, forceRefresh: Boolean = false) {
@@ -593,6 +600,8 @@ private fun ExpandedPlayer(
         lyricsUiVersion = settings.lyricsUiVersion,
         lyricsAnimation = settings.lyricsAnimation,
         wavySeekbarEnabled = settings.wavySeekbarEnabled,
+        autoplayEnabled = settings.autoplayEnabled,
+        onAutoplayChange = viewModel::setAutoplayEnabled,
         currentTab = currentTab,
         onTabChange = onTabChange,
         onRetryLyrics = onRetryLyrics,
@@ -1351,6 +1360,8 @@ private fun FullPlayer(
     lyricsUiVersion: LyricsUiVersion = LyricsUiVersion.CLASSIC,
     lyricsAnimation: LyricsAnimation = LyricsAnimation.APPLE_FLUID,
     wavySeekbarEnabled: Boolean = true,
+    autoplayEnabled: Boolean = true,
+    onAutoplayChange: (Boolean) -> Unit = {},
     currentTab: FullPlayerTab,
     onTabChange: (FullPlayerTab) -> Unit,
     onRetryLyrics: () -> Unit,
@@ -1714,9 +1725,11 @@ private fun FullPlayer(
 
                         FullPlayerTab.QUEUE -> {
                             QueuePanel(
-                                state,
-                                player,
-                                Modifier
+                                state = state,
+                                player = player,
+                                autoplayEnabled = autoplayEnabled,
+                                onAutoplayChange = onAutoplayChange,
+                                modifier = Modifier
                                     .fillMaxSize()
                                     .adaptiveContentWidth(maxWidth = 720.dp)
                                     .padding(horizontal = 20.dp),
@@ -2192,60 +2205,17 @@ internal fun PlayerProgressSlider(
     enabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val primary = MaterialTheme.colorScheme.primary
-    val tertiary = MaterialTheme.colorScheme.tertiary
-    val inactive = MaterialTheme.colorScheme.onSurface.copy(alpha = if (enabled) 0.20f else 0.12f)
-    val range = (valueRange.endInclusive - valueRange.start).coerceAtLeast(0.0001f)
-    val fraction = ((value - valueRange.start) / range).coerceIn(0f, 1f)
-
-    Slider(
+    // Same circular knob as the Now Playing seekbar, so the classic slider and
+    // the wavy one read as the same control in different clothes.
+    ExpressiveSlider(
         value = value,
         onValueChange = onValueChange,
         onValueChangeFinished = onValueChangeFinished,
         valueRange = valueRange,
         enabled = enabled,
-        modifier = modifier.drawBehind {
-            val inset = 10.dp.toPx()
-            val startX = inset
-            val endX = (size.width - inset).coerceAtLeast(startX)
-            val activeEndX = startX + ((endX - startX) * fraction)
-            val centerY = size.height / 2f
-            drawLine(
-                color = inactive,
-                start = androidx.compose.ui.geometry.Offset(startX, centerY),
-                end = androidx.compose.ui.geometry.Offset(endX, centerY),
-                strokeWidth = 3.dp.toPx(),
-                cap = StrokeCap.Round,
-            )
-            if (activeEndX > startX) {
-                drawLine(
-                    brush = Brush.horizontalGradient(
-                        colors = listOf(
-                            primary.copy(alpha = if (enabled) 1f else 0.42f),
-                            tertiary.copy(alpha = if (enabled) 0.92f else 0.36f),
-                        ),
-                        startX = startX,
-                        endX = activeEndX,
-                    ),
-                    start = androidx.compose.ui.geometry.Offset(startX, centerY),
-                    end = androidx.compose.ui.geometry.Offset(activeEndX, centerY),
-                    strokeWidth = 4.dp.toPx(),
-                    cap = StrokeCap.Round,
-                )
-            }
-        },
-        colors = SliderDefaults.colors(
-            thumbColor = primary,
-            activeTrackColor = Color.Transparent,
-            inactiveTrackColor = Color.Transparent,
-            activeTickColor = Color.Transparent,
-            inactiveTickColor = Color.Transparent,
-            disabledThumbColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f),
-            disabledActiveTrackColor = Color.Transparent,
-            disabledInactiveTrackColor = Color.Transparent,
-            disabledActiveTickColor = Color.Transparent,
-            disabledInactiveTickColor = Color.Transparent,
-        ),
+        modifier = modifier,
+        activeColor = MaterialTheme.colorScheme.primary,
+        inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = if (enabled) 0.20f else 0.12f),
     )
 }
 
@@ -2303,25 +2273,25 @@ private fun SeekBar(
                 .height(44.dp),
             contentAlignment = Alignment.Center,
         ) {
+            val surfaceColor = MaterialTheme.colorScheme.surface
             Canvas(modifier = Modifier.fillMaxWidth().height(44.dp)) {
                 val width = size.width
                 val height = size.height
                 val centerY = height / 2f
                 val trackHeightPx = 14.dp.toPx()
                 val cornerRadius = CornerRadius(trackHeightPx / 2f, trackHeightPx / 2f)
-                val thumbWidthPx = 5.dp.toPx()
-                val thumbHeightPx = 38.dp.toPx()
-                val thumbClearancePx = 9.dp.toPx()
+                val thumbRadiusPx = 10.dp.toPx()
+                val thumbClearancePx = thumbRadiusPx + 3.dp.toPx()
                 val rawThumbCenterX = fraction * width
-                val thumbCenterX = if (width > thumbWidthPx) {
-                    rawThumbCenterX.coerceIn(thumbWidthPx / 2f, width - thumbWidthPx / 2f)
+                val thumbCenterX = if (width > thumbRadiusPx * 2f) {
+                    rawThumbCenterX.coerceIn(thumbRadiusPx, width - thumbRadiusPx)
                 } else {
                     width / 2f
                 }
                 val activeEndX = (thumbCenterX - thumbClearancePx).coerceIn(0f, width)
                 val inactiveStartX = (thumbCenterX + thumbClearancePx).coerceIn(0f, width)
 
-                // Thick active capsule ending before the vertical thumb.
+                // Thick active capsule ending before the circular thumb.
                 if (activeEndX > 0f) {
                     drawRoundRect(
                         color = primaryColor,
@@ -2331,7 +2301,7 @@ private fun SeekBar(
                     )
                 }
 
-                // Thick inactive capsule starting after the vertical thumb.
+                // Thick inactive capsule starting after the circular thumb.
                 if (inactiveStartX < width) {
                     drawRoundRect(
                         color = inactiveColor,
@@ -2351,15 +2321,21 @@ private fun SeekBar(
                     )
                 }
 
-                // Tall vertical pill thumb with clear space on both sides.
-                val thumbX = thumbCenterX - thumbWidthPx / 2f
-                val thumbCornerRadius = CornerRadius(thumbWidthPx / 2f, thumbWidthPx / 2f)
-
-                drawRoundRect(
+                // Sleek circular thumb knob with subtle depth halo and crisp inner core
+                drawCircle(
+                    color = primaryColor.copy(alpha = 0.22f),
+                    radius = thumbRadiusPx + 3.dp.toPx(),
+                    center = Offset(thumbCenterX, centerY),
+                )
+                drawCircle(
                     color = primaryColor,
-                    topLeft = Offset(thumbX, centerY - thumbHeightPx / 2f),
-                    size = Size(thumbWidthPx, thumbHeightPx),
-                    cornerRadius = thumbCornerRadius,
+                    radius = thumbRadiusPx,
+                    center = Offset(thumbCenterX, centerY),
+                )
+                drawCircle(
+                    color = surfaceColor,
+                    radius = 3.5.dp.toPx(),
+                    center = Offset(thumbCenterX, centerY),
                 )
             }
 
@@ -2657,7 +2633,13 @@ private fun PlayerUtilityControls(state: MusicPlayerState, player: MusicPlayer, 
 
 @OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
-private fun QueuePanel(state: MusicPlayerState, player: MusicPlayer, modifier: Modifier = Modifier) {
+private fun QueuePanel(
+    state: MusicPlayerState,
+    player: MusicPlayer,
+    autoplayEnabled: Boolean = true,
+    onAutoplayChange: (Boolean) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
     Column(modifier) {
         Row(
             Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 4.dp),
@@ -2686,6 +2668,43 @@ private fun QueuePanel(state: MusicPlayerState, player: MusicPlayer, modifier: M
                 Icon(Icons.Filled.ClearAll, "Clear upcoming songs")
             }
         }
+
+        // Endless playback: keeps the queue growing with similar songs once
+        // the loaded tail runs out, instead of stopping at the last track.
+        Surface(
+            onClick = { onAutoplayChange(!autoplayEnabled) },
+            shape = RoundedCornerShape(20.dp),
+            color = if (autoplayEnabled) {
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f)
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            },
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 2.dp),
+        ) {
+            Row(
+                Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Filled.AllInclusive,
+                    contentDescription = null,
+                    tint = if (autoplayEnabled) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+                Column(Modifier.weight(1f).padding(horizontal = 12.dp)) {
+                    Text("Autoplay", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        if (autoplayEnabled) "Keep playing similar songs when the queue ends"
+                        else "Stop when the queue ends",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(checked = autoplayEnabled, onCheckedChange = onAutoplayChange)
+            }
+        }
+        Spacer(Modifier.height(10.dp))
         LazyColumn(
             Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/com/lastwave/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/lastwave/app/ui/settings/SettingsScreen.kt
@@ -76,6 +76,11 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.QueueMusic
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FormatListBulleted
+import androidx.compose.material.icons.filled.AllInclusive
+import androidx.compose.material.icons.filled.LibraryMusic
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.SystemUpdate
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -90,7 +95,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Slider
+import com.lastwave.app.ui.common.ExpressiveSlider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -808,6 +813,44 @@ fun SettingsScreen(
 
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    SectionLabel("Playback & Local Library")
+                    SettingsGroup(rowCount = 2) { index, position ->
+                        when (index) {
+                            0 -> SettingsToggleCard(
+                                icon = Icons.Filled.AllInclusive,
+                                iconContainer = MaterialTheme.colorScheme.primaryContainer,
+                                iconTint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                title = "Autoplay",
+                                subtitle = if (misc.autoplayEnabled) {
+                                    "Keep playing similar songs when a queue ends"
+                                } else {
+                                    "Stop playback when the queue ends"
+                                },
+                                checked = misc.autoplayEnabled,
+                                onCheckedChange = viewModel::setAutoplayEnabled,
+                                position = position,
+                            )
+                            1 -> SettingsToggleCard(
+                                icon = Icons.Filled.LibraryMusic,
+                                iconContainer = MaterialTheme.colorScheme.tertiaryContainer,
+                                iconTint = MaterialTheme.colorScheme.onTertiaryContainer,
+                                title = "Scan Device Music",
+                                subtitle = if (misc.scanFullDeviceAudio) {
+                                    "Index every song on this phone, not just downloads"
+                                } else {
+                                    "Only show songs downloaded by LastWave"
+                                },
+                                checked = misc.scanFullDeviceAudio,
+                                onCheckedChange = viewModel::setScanFullDeviceAudio,
+                                position = position,
+                            )
+                        }
+                    }
+                }
+            }
+
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     SectionLabel("Library & Playlist Imports")
                     SettingsGroup(rowCount = 1) { _, position ->
                         SettingsActionCard(
@@ -971,7 +1014,6 @@ fun SettingsScreen(
                         }
                     }
                     Spacer(Modifier.height(4.dp))
-
                     // Prominent Update Available Banner Card (if newer version detected)
                     if (updateInfo.isUpdateAvailable) {
                         Surface(
@@ -1032,7 +1074,6 @@ fun SettingsScreen(
                         }
                         Spacer(Modifier.height(8.dp))
                     }
-
                     AboutCard(versionName = appVersionName(context))
 
                     SettingsActionCard(
@@ -1688,7 +1729,7 @@ private fun ScrobbleThresholdRow(percent: Int, onPercentChange: (Int) -> Unit, p
                     )
                 }
             }
-            Slider(
+            ExpressiveSlider(
                 value = sliderValue,
                 onValueChange = { sliderValue = it },
                 onValueChangeFinished = { onPercentChange(sliderValue.toInt()) },
@@ -1759,7 +1800,7 @@ private fun CrossfadeDurationRow(
                     )
                 }
             }
-            Slider(
+            ExpressiveSlider(
                 value = sliderValue,
                 onValueChange = { value ->
                     isDragging = true
@@ -1917,6 +1958,64 @@ private fun relativeTime(timestampMillis: Long): String {
         else -> "${minutes / (60 * 24)}d ago"
     }
 }
+
+/** Shown instead of [AccountCard] while running as a guest: the app works
+ *  fully offline/local, but scrobbling and taste-based mixes need Last.fm. */
+@Composable
+private fun GuestAccountCard(onConnect: () -> Unit) {
+    Card(
+        shape = CardOuterShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        modifier = Modifier.fillMaxWidth().animateContentSize(),
+    ) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.secondaryContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Filled.Person,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
+                Spacer(Modifier.width(14.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Last.fm Account",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        "Browsing as Guest",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+            Text(
+                "Connect Last.fm to scrobble your plays and unlock personalised mixes, " +
+                    "recommendations and friends.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            Button(
+                onClick = onConnect,
+                shape = ExpressivePillShape,
+                modifier = Modifier.fillMaxWidth().height(46.dp),
+            ) {
+                Text("Connect Last.fm account", fontWeight = FontWeight.Medium)
+            }
+        }
+    }
+}
+
 
 @Composable
 private fun AccountCard(
@@ -2342,11 +2441,11 @@ private fun ColorWheelSheet(onDismiss: () -> Unit, onApply: (Color) -> Unit) {
             )
             Spacer(Modifier.height(20.dp))
             Text("Hue", style = MaterialTheme.typography.labelLarge)
-            Slider(value = hue, onValueChange = { hue = it }, valueRange = 0f..360f)
+            ExpressiveSlider(value = hue, onValueChange = { hue = it }, valueRange = 0f..360f)
             Text("Saturation", style = MaterialTheme.typography.labelLarge)
-            Slider(value = saturation, onValueChange = { saturation = it }, valueRange = 0f..1f)
+            ExpressiveSlider(value = saturation, onValueChange = { saturation = it }, valueRange = 0f..1f)
             Text("Lightness", style = MaterialTheme.typography.labelLarge)
-            Slider(value = lightness, onValueChange = { lightness = it }, valueRange = 0.15f..0.85f)
+            ExpressiveSlider(value = lightness, onValueChange = { lightness = it }, valueRange = 0.15f..0.85f)
             Spacer(Modifier.height(12.dp))
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 OutlinedButton(onClick = onDismiss, shape = ExpressivePillShape, modifier = Modifier.weight(1f).height(48.dp)) { Text("Cancel") }

--- a/app/src/main/java/com/lastwave/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/lastwave/app/ui/settings/SettingsViewModel.kt
@@ -88,6 +88,7 @@ class SettingsViewModel @Inject constructor(
     private val ytMusicPreferences: com.lastwave.app.data.ytmusic.YtMusicPreferences,
     private val ytMusicLibraryManager: com.lastwave.app.data.ytmusic.YtMusicLibraryManager,
     private val downloadedTrackDao: com.lastwave.app.data.local.db.DownloadedTrackDao,
+    private val downloadManager: com.lastwave.app.data.download.TrackDownloadManager,
     val playlistImportManager: com.lastwave.app.data.playlist.PlaylistImportManager,
     val innerTube: com.lastwave.app.data.music.InnerTubeMusicApi,
     val appUpdateManager: com.lastwave.app.data.update.AppUpdateManager,
@@ -285,6 +286,16 @@ class SettingsViewModel @Inject constructor(
     fun setDownloadLyrics(enabled: Boolean) = launchSettingsAction("update download lyrics setting") {
         settingsPreferences.setDownloadLyrics(enabled)
     }
+    fun setAutoplayEnabled(enabled: Boolean) = launchSettingsAction("update autoplay setting") {
+        settingsPreferences.setAutoplayEnabled(enabled)
+    }
+    fun setScanFullDeviceAudio(enabled: Boolean) = launchSettingsAction("update device library scanning") {
+        settingsPreferences.setScanFullDeviceAudio(enabled)
+        // Re-index straight away so the change is visible without a restart.
+        runCatching { downloadManager.syncDownloadsFromStorage() }
+            .onFailure { android.util.Log.e(SETTINGS_TAG, "Local library rescan failed", it) }
+    }
+
 
     // ── Experimental: 15-band equalizer ──
 

--- a/app/src/main/java/com/lastwave/app/ui/shell/MainShell.kt
+++ b/app/src/main/java/com/lastwave/app/ui/shell/MainShell.kt
@@ -130,7 +130,9 @@ object FloatingNavDefaults {
 private val DockShape: Shape = RoundedCornerShape(32.dp)
 private val PillShape: Shape = CircleShape
 
-private fun <T> navSpring() = ExpressiveMotion.spatialSpring<T>()
+// One shared smooth spring keeps tab selection, label expansion, and pager controls
+// visually coherent and silky smooth without jittery oscillations.
+private fun <T> navSpring() = ExpressiveMotion.smoothSpring<T>()
 
 @Composable
 fun MainShell(
@@ -158,13 +160,22 @@ fun MainShell(
         val feedIndex = tabs.indexOf(MainTab.FEED)
         HorizontalPager(
             state = pagerState,
-            beyondViewportPageCount = 0,
+            // Pre-warm neighboring tabs in GPU memory so horizontal sliding is
+            // a hardware-accelerated translation with zero first-frame composition hitch.
+            beyondViewportPageCount = 1,
             modifier = Modifier.fillMaxSize().liquidGlassSource(navigationBackdrop),
         ) { page ->
             val isCurrent = page == pagerState.currentPage
             PredictiveBackScreen(
                 enabled = isCurrent && tabs[page] != MainTab.FEED,
-                onBack = { scope.launch { pagerState.animateScrollToPage(feedIndex) } },
+                onBack = {
+                    scope.launch {
+                        pagerState.animateScrollToPage(
+                            page = feedIndex,
+                            animationSpec = ExpressiveMotion.smoothSpring(),
+                        )
+                    }
+                },
             ) {
                 when (tabs[page]) {
                     MainTab.FEED -> FeedScreen(
@@ -212,8 +223,15 @@ fun MainShell(
         FloatingNavBar(
             backdrop = navigationBackdrop,
             tabs = tabs,
-            selectedIndex = pagerState.currentPage,
-            onSelect = { index -> scope.launch { pagerState.animateScrollToPage(index) } },
+            selectedIndex = pagerState.targetPage,
+            onSelect = { index ->
+                scope.launch {
+                    pagerState.animateScrollToPage(
+                        page = index,
+                        animationSpec = ExpressiveMotion.smoothSpring(),
+                    )
+                }
+            },
             onOpenGenerator = onOpenGenerator,
             modifier = Modifier.align(Alignment.BottomCenter),
         )


### PR DESCRIPTION
## Overview
This PR brings major UI fluidity, modern slider styling, and playback enhancements to LastWave:

### 1. Buttery-Smooth Tab Navigation & Reactive Dock (MainShell.kt)
- **Problem:** When swiping or switching tabs on 90Hz / 120Hz displays, horizontal transitions exhibited stutter due to cold first-frame composition (`beyondViewportPageCount = 0`) and delayed pill animations.
- **Solution:** 
  - Enabled `beyondViewportPageCount = 1` so adjacent screen layouts stay cached in GPU composition memory.
  - Bound the floating dock selection to `pagerState.targetPage` for instantaneous pill response on finger tap.
  - Tuned dock pill animation with non-oscillating `ExpressiveMotion.smoothSpring()`.

### 2. Sleek Circular Slider Thumbs (ExpressiveSlider.kt & PlayerHost.kt)
- **Problem:** Seekbars and settings sliders previously used tall 38dp vertical bars and default Material rectangular capsules.
- **Solution:**
  - Redesigned the expanded player seekbar thumb into a sleek circular knob with depth halo and inner surface core.
  - Created reusable `ExpressiveSlider` (in `ui/common/`) featuring capsule tracks and dynamic halo expansion on drag/press, applied across Settings (EQ gain, volume, color pickers) and Generator.

### 3. YouTube-Music-Style Infinite Autoplay (MusicPlayer.kt)
- **Problem:** Music abruptly ended when an album or playlist finished.
- **Solution:**
  - Seamlessly extends ordinary playback queues with similar tracks via Last.fm API recommendations and Discover fallback.
  - Proactively queries for refills before the queue runs out, with fallback resumption if playback reached the end.
  - User-toggleable in Now Playing queue sheet and in Settings.

### 4. Full-Device Local Music Scanner (TrackDownloadManager.kt)
- **Problem:** The local library scanner previously only checked `Music/LastWave%`, ignoring user audio in other device folders (`Music/`, `Download/`, etc.).
- **Solution:**
  - Expanded MediaStore query to index all valid audio tracks (`IS_MUSIC != 0`) across device storage, filtering out short audio clips (<30s).
  - Added safety guards ensuring `deleteDownloadedTrack` only deletes physical files that LastWave owns, keeping personal user audio untouched.
  - Declared `READ_MEDIA_AUDIO` for Android 13+ with runtime permission checks.

### 5. In-App GitHub Auto-Updater (AppUpdateManager.kt & SettingsScreen.kt)
- Added direct GitHub release checking against `Clash-Projects/LastWave-native/releases/latest`.
- Displays current vs latest version badge, changelog dialog ("What's new"), and direct release/APK download in Settings.

---

### Verification
- Tested and verified with `./gradlew compileDebugKotlin` and `./gradlew assembleDebug` (0 compiler warnings/errors, all native Oboe ABIs compiled).
- Tested on Android device with smooth 90 FPS tab scrolling.