### PR TITLE
fix: play downloaded tracks offline via MediaStore fallback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <!-- Android 13+: required to read audio files in shared storage
+        (e.g. orphaned Music/LastWave downloads after reinstall). -->
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
         android:name=".LastWaveApplication"

--- a/app/src/main/java/com/lastwave/app/MainActivity.kt
+++ b/app/src/main/java/com/lastwave/app/MainActivity.kt
@@ -38,6 +38,8 @@ class MainActivity : androidx.fragment.app.FragmentActivity() {
 
     private val notificationPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
 
+    private val audioMediaPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         // Must be called before super.onCreate() and before setContent().
         val splashScreen = runCatching { installSplashScreen() }
@@ -82,6 +84,15 @@ class MainActivity : androidx.fragment.app.FragmentActivity() {
         ) {
             runCatching { notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS) }
                 .onFailure { android.util.Log.w(STARTUP_TAG, "Notification permission request skipped", it) }
+        }
+        // Android 13+: offline playback of previously downloaded files in
+        // shared storage (Music/LastWave) requires this to resolve orphaned
+        // files via MediaStore when the download database has no record.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            checkSelfPermission(Manifest.permission.READ_MEDIA_AUDIO) != PackageManager.PERMISSION_GRANTED
+        ) {
+            runCatching { audioMediaPermission.launch(Manifest.permission.READ_MEDIA_AUDIO) }
+                .onFailure { android.util.Log.w(STARTUP_TAG, "Audio media permission request skipped", it) }
         }
 
         setContent {

--- a/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
+++ b/app/src/main/java/com/lastwave/app/data/download/TrackDownloadManager.kt
@@ -130,7 +130,12 @@ class TrackDownloadManager @Inject constructor(
         const val EXTRA_DOWNLOAD_TITLE = "download_title"
         const val EXTRA_DOWNLOAD_ARTIST = "download_artist"
         const val EXTRA_NAVIGATE_TO = "navigate_to"
-        private const val PUBLIC_DIR_NAME = "LastWave"
+        /** Public `Music/` subdirectory downloads are written to. Public so the
+         * playback layer can probe it as an offline fallback without
+         * hard-coding the directory. */
+        const val PUBLIC_DIR_NAME = "LastWave"
+        /** Audio extensions recognized as playable downloads, in probe order. */
+        val DOWNLOAD_AUDIO_EXTENSIONS = listOf("flac", "m4a", "opus", "mp3", "webm")
         private const val DOWNLOAD_BUFFER_SIZE = 512 * 1024 // 512 KB
         private const val PARALLEL_YOUTUBE_PARTS = 4
         private const val MIN_PARALLEL_DOWNLOAD_BYTES = 2L * 1024 * 1024
@@ -144,6 +149,11 @@ class TrackDownloadManager @Inject constructor(
 
         fun makeDownloadKey(title: String, artist: String): String =
             "${artist.trim().lowercase()}_${title.trim().lowercase()}"
+
+        /** Filename sanitization shared by the downloader and the playback
+         * offline fallback so both sides resolve the same on-disk name. */
+        fun sanitizeDownloadFilename(name: String): String =
+            name.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().ifBlank { "track" }
     }
 
     // Dedicated HTTP client with extended timeouts and high-throughput connection pooling
@@ -232,8 +242,7 @@ class TrackDownloadManager @Inject constructor(
         val publicDir = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC), PUBLIC_DIR_NAME)
         if (publicDir.exists() && publicDir.isDirectory) {
             val sanitizedBase = sanitizeFilename("${artist.trim()} - ${title.trim()}")
-            val candidateExtensions = listOf("flac", "m4a", "opus", "mp3", "webm")
-            if (candidateExtensions.any { ext ->
+            if (DOWNLOAD_AUDIO_EXTENSIONS.any { ext ->
                     val f = File(publicDir, "$sanitizedBase.$ext")
                     f.exists() && f.length() > 0
                 }
@@ -309,8 +318,7 @@ class TrackDownloadManager @Inject constructor(
                 val publicDir = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC), PUBLIC_DIR_NAME)
                 if (publicDir.exists() && publicDir.isDirectory) {
                     val sanitizedBase = sanitizeFilename("${artist.trim()} - ${title.trim()}")
-                    val candidateExtensions = listOf("flac", "m4a", "opus", "mp3", "webm")
-                    val existingFile = candidateExtensions.map { File(publicDir, "$sanitizedBase.$it") }
+                    val existingFile = DOWNLOAD_AUDIO_EXTENSIONS.map { File(publicDir, "$sanitizedBase.$it") }
                         .firstOrNull { it.exists() && it.length() > 0 }
                     if (existingFile != null) {
                         activeKeys.remove(key)
@@ -1691,5 +1699,5 @@ class TrackDownloadManager @Inject constructor(
     }
 
     private fun sanitizeFilename(title: String): String =
-        title.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().ifBlank { "track" }
+        sanitizeDownloadFilename(title)
 }

--- a/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
+++ b/app/src/main/java/com/lastwave/app/playback/MusicPlayer.kt
@@ -1,10 +1,12 @@
 package com.lastwave.app.playback
 
+import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.SystemClock
+import android.provider.MediaStore
 import androidx.annotation.MainThread
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
@@ -2078,54 +2080,185 @@ class MusicPlayer @Inject constructor(
         val artist = track.artist.trim()
         if (title.isBlank() || artist.isBlank()) return null
 
-        val trackKey = "${artist.lowercase()}_${title.lowercase()}"
+        val trackKey = OfflinePlaybackResolver.makeDownloadKey(title, artist)
         val downloaded = runCatching {
             val dao = downloadedTrackDao.get()
             dao.findByTrackKey(trackKey) ?: dao.findByTitleAndArtist(title, artist)
+        }.getOrNull()
+
+        if (downloaded != null) {
+            val uriString = OfflinePlaybackResolver.rawLocalUriString(downloaded)
+            if (uriString != null && isLocalUriAccessible(uriString)) {
+                val playbackUri = OfflinePlaybackResolver.toPlaybackUriString(uriString)
+                return buildLocalDownloadStream(
+                    trackKey = trackKey,
+                    playbackUri = playbackUri,
+                    filePath = downloaded.filePath,
+                    formatBadge = downloaded.formatBadge,
+                    bitrateKbps = downloaded.bitrateKbps,
+                    isLossless = downloaded.isLossless,
+                )
+            }
+            // Stale database record; file was deleted externally outside the app.
+            // Fall through to the on-disk probe below before giving up to remote.
+            runCatching { downloadedTrackDao.get().delete(downloaded) }
+        }
+
+        // Second chance when the Room lookup misses (history cleared,
+        // reinstall, sync not yet run) or the stored row was stale: probe
+        // MediaStore.Audio for the downloader's public file first. On
+        // Android 13+ direct File access to shared storage is gated behind
+        // READ_MEDIA_AUDIO, so a content:// URI is the only playable handle
+        // for orphaned files (DB row gone, file still on disk).
+        findPublicDownloadContentUri(title, artist)?.let { (contentUriString, displayName) ->
+            return buildLocalDownloadStream(
+                trackKey = trackKey,
+                playbackUri = contentUriString,
+                filePath = displayName,
+                formatBadge = null,
+                bitrateKbps = null,
+                isLossless = displayName.endsWith(".flac", ignoreCase = true),
+            )
+        }
+
+        // Legacy same-install / pre-Android 10 fallback: direct File probe of
+        // the downloader's public directory.
+        val fallbackFile = runCatching {
+            val musicDir = File(
+                android.os.Environment.getExternalStoragePublicDirectory(
+                    android.os.Environment.DIRECTORY_MUSIC,
+                ),
+                com.lastwave.app.data.download.TrackDownloadManager.PUBLIC_DIR_NAME,
+            )
+            OfflinePlaybackResolver.findPublicDownloadFile(
+                musicDir = musicDir,
+                title = title,
+                artist = artist,
+                sanitize = com.lastwave.app.data.download.TrackDownloadManager::sanitizeDownloadFilename,
+                extensions = com.lastwave.app.data.download.TrackDownloadManager.DOWNLOAD_AUDIO_EXTENSIONS,
+            )
         }.getOrNull() ?: return null
 
-        val uriString = downloaded.mediaStoreUri?.takeIf(String::isNotBlank)
-            ?: downloaded.filePath.takeIf(String::isNotBlank)
-            ?: return null
+        return buildLocalDownloadStream(
+            trackKey = trackKey,
+            playbackUri = OfflinePlaybackResolver.toPlaybackUriString(fallbackFile.absolutePath),
+            filePath = fallbackFile.absolutePath,
+            formatBadge = null,
+            bitrateKbps = null,
+            isLossless = fallbackFile.extension.equals("flac", ignoreCase = true),
+        )
+    }
 
-        val isAccessible = when {
-            uriString.startsWith("content://") -> runCatching {
-                appContext.contentResolver.openInputStream(Uri.parse(uriString))?.use { }
-                true
-            }.getOrDefault(false)
-            else -> runCatching {
-                val file = if (uriString.startsWith("file://")) {
-                    File(Uri.parse(uriString).path.orEmpty())
-                } else {
-                    File(uriString)
-                }
-                file.exists() && file.length() > 0
-            }.getOrDefault(false)
-        }
-
-        if (!isAccessible) {
-            // Stale database record; file was deleted externally outside the app
-            runCatching { downloadedTrackDao.get().delete(downloaded) }
-            return null
-        }
-
-        val playbackUri = if (uriString.startsWith("/") && !uriString.startsWith("file://")) {
-            Uri.fromFile(File(uriString)).toString()
+    /**
+     * MediaStore probe for an orphaned download: finds
+     * `"artist - title".ext` under the downloader's public directory without
+     * consulting Room, and returns its playable `content://` URI plus display
+     * name. Prefers rows whose relative path contains
+     * [TrackDownloadManager.PUBLIC_DIR_NAME] so a same-named track elsewhere
+     * on the device doesn't win. Returns null when nothing readable exists.
+     */
+    private fun findPublicDownloadContentUri(
+        title: String,
+        artist: String,
+    ): Pair<String, String>? {
+        val base = OfflinePlaybackResolver.publicDownloadBaseName(
+            title = title,
+            artist = artist,
+            sanitize = com.lastwave.app.data.download.TrackDownloadManager::sanitizeDownloadFilename,
+        )
+        val extensions = com.lastwave.app.data.download.TrackDownloadManager.DOWNLOAD_AUDIO_EXTENSIONS
+        val resolver = appContext.contentResolver
+        val collection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL)
         } else {
-            uriString
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
         }
+        val includePath = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        var fallback: Pair<String, String>? = null
+        for (displayName in extensions.map { "$base.$it" }) {
+            val preferred = runCatching {
+                val projection = buildList {
+                    add(MediaStore.Audio.Media._ID)
+                    add(MediaStore.Audio.Media.DISPLAY_NAME)
+                    if (includePath) add(MediaStore.Audio.Media.RELATIVE_PATH)
+                }
+                resolver.query(
+                    collection,
+                    projection.toTypedArray(),
+                    "${MediaStore.Audio.Media.DISPLAY_NAME} = ?",
+                    arrayOf(displayName),
+                    null,
+                )?.use { cursor ->
+                    val idCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+                    val nameCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+                    val pathCol = if (includePath) {
+                        cursor.getColumnIndex(MediaStore.Audio.Media.RELATIVE_PATH)
+                    } else {
+                        -1
+                    }
+                    while (cursor.moveToNext()) {
+                        val id = cursor.getLong(idCol)
+                        val name = cursor.getString(nameCol) ?: continue
+                        val relativePath = if (pathCol >= 0) {
+                            runCatching { cursor.getString(pathCol) }.getOrNull().orEmpty()
+                        } else {
+                            ""
+                        }
+                        val contentUri = ContentUris.withAppendedId(collection, id).toString()
+                        // Skip rows we can't actually open.
+                        if (!isLocalUriAccessible(contentUri)) continue
+                        val hit = contentUri to name
+                        if (relativePath.contains(
+                                com.lastwave.app.data.download.TrackDownloadManager.PUBLIC_DIR_NAME,
+                                ignoreCase = true,
+                            )
+                        ) {
+                            return@use hit
+                        }
+                        if (fallback == null) fallback = hit
+                    }
+                    null
+                }
+            }.getOrNull()
+            if (preferred != null) return preferred
+        }
+        return fallback
+    }
 
+    private fun isLocalUriAccessible(uriString: String): Boolean = when {
+        uriString.startsWith("content://") -> runCatching {
+            appContext.contentResolver.openInputStream(Uri.parse(uriString))?.use { }
+            true
+        }.getOrDefault(false)
+        else -> runCatching {
+            val file = if (uriString.startsWith("file://")) {
+                File(Uri.parse(uriString).path.orEmpty())
+            } else {
+                File(uriString)
+            }
+            file.exists() && file.length() > 0
+        }.getOrDefault(false)
+    }
+
+    private fun buildLocalDownloadStream(
+        trackKey: String,
+        playbackUri: String,
+        filePath: String,
+        formatBadge: String?,
+        bitrateKbps: Int?,
+        isLossless: Boolean,
+    ): ResolvedStream {
         val mime = when {
-            downloaded.filePath.endsWith(".flac", ignoreCase = true) || downloaded.formatBadge.contains("FLAC") -> "audio/flac"
-            downloaded.filePath.endsWith(".m4a", ignoreCase = true) || downloaded.filePath.endsWith(".mp4", ignoreCase = true) || downloaded.formatBadge.contains("M4A") -> "audio/mp4"
-            downloaded.filePath.endsWith(".opus", ignoreCase = true) || downloaded.formatBadge.contains("OPUS") -> "audio/ogg"
-            downloaded.filePath.endsWith(".mp3", ignoreCase = true) || downloaded.formatBadge.contains("MP3") -> "audio/mpeg"
+            filePath.endsWith(".flac", ignoreCase = true) || formatBadge?.contains("FLAC") == true -> "audio/flac"
+            filePath.endsWith(".m4a", ignoreCase = true) || filePath.endsWith(".mp4", ignoreCase = true) || formatBadge?.contains("M4A") == true -> "audio/mp4"
+            filePath.endsWith(".opus", ignoreCase = true) || formatBadge?.contains("OPUS") == true -> "audio/ogg"
+            filePath.endsWith(".mp3", ignoreCase = true) || formatBadge?.contains("MP3") == true -> "audio/mpeg"
             else -> "audio/flac"
         }
 
         var bitDepth: Int? = null
         var samplingRateKHz: Double? = null
-        var bitrateKbps: Int? = downloaded.bitrateKbps
+        var resolvedBitrateKbps: Int? = bitrateKbps
 
         runCatching {
             val retriever = android.media.MediaMetadataRetriever()
@@ -2135,8 +2268,8 @@ class MusicPlayer @Inject constructor(
                 } else {
                     retriever.setDataSource(playbackUri.removePrefix("file://"))
                 }
-                if (bitrateKbps == null || bitrateKbps == 0) {
-                    bitrateKbps = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toIntOrNull()?.let { it / 1000 }
+                if (resolvedBitrateKbps == null || resolvedBitrateKbps == 0) {
+                    resolvedBitrateKbps = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toIntOrNull()?.let { it / 1000 }
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     samplingRateKHz = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_SAMPLERATE)?.toDoubleOrNull()?.let { it / 1000.0 }
@@ -2150,10 +2283,10 @@ class MusicPlayer @Inject constructor(
         return ResolvedStream(
             url = playbackUri,
             mimeType = mime,
-            bitrateKbps = bitrateKbps,
-            audioCodec = downloaded.formatBadge,
+            bitrateKbps = resolvedBitrateKbps,
+            audioCodec = formatBadge ?: filePath.substringAfterLast('.', "").uppercase(),
             cacheKey = "local:$trackKey",
-            isLossless = downloaded.isLossless,
+            isLossless = isLossless,
             bitDepth = bitDepth,
             samplingRateKHz = samplingRateKHz,
         )

--- a/app/src/main/java/com/lastwave/app/playback/OfflinePlaybackResolver.kt
+++ b/app/src/main/java/com/lastwave/app/playback/OfflinePlaybackResolver.kt
@@ -1,0 +1,157 @@
+package com.lastwave.app.playback
+
+import com.lastwave.app.data.local.db.DownloadedTrackEntity
+
+/**
+ * Offline-first playback resolution.
+ *
+ * Single place that decides whether a requested track already has a valid
+ * local download. When it does, Media3/ExoPlayer must play that local file
+ * instead of resolving the remote URL — including when the network is
+ * unavailable.
+ *
+ * Flow:
+ * ```
+ * Play requested -> Is this track downloaded locally?
+ *   YES -> Play local file
+ *   NO  -> Existing remote streaming/resolution logic
+ * ```
+ *
+ * Stale records (DB row present but local file missing/unreadable) are
+ * reported via [onStaleDownload] so callers can reuse their existing cleanup
+ * (e.g. delete the row) and then keep looking: first the public download
+ * directory on disk, and only then remote resolution.
+ *
+ * The public-directory probe is the second-chance path for when the Room
+ * lookup misses entirely (history cleared, reinstall, sync not yet run) or
+ * the stored row is stale but the file is still on disk. It reuses the
+ * downloader's own naming (sanitized `"artist - title"` + known audio
+ * extensions), injected as lambdas so this object stays free of Android
+ * framework dependencies and unit-testable on the JVM.
+ *
+ * Pure Kotlin (no Android framework dependency) so the decision table is
+ * unit-testable on the JVM.
+ */
+object OfflinePlaybackResolver {
+
+    /**
+     * Normalized download key. Must stay in sync with
+     * `TrackDownloadManager.makeDownloadKey` ("${artist}_${title}",
+     * trimmed + lowercased) so playback lookups hit the same rows that the
+     * download manager writes (unique `trackKey` index).
+     */
+    fun makeDownloadKey(title: String, artist: String): String =
+        "${artist.trim().lowercase()}_${title.trim().lowercase()}"
+
+    /**
+     * Raw stored location for a download: MediaStore `content://` URI when
+     * present, otherwise the filesystem path. Returns null when the record
+     * carries no usable location.
+     */
+    fun rawLocalUriString(downloaded: DownloadedTrackEntity): String? =
+        downloaded.mediaStoreUri?.takeIf { it.isNotBlank() }
+            ?: downloaded.filePath.takeIf { it.isNotBlank() }
+
+    /**
+     * Maps a stored download location to a playback URI string for Media3:
+     * - `content://` URIs are passed through unchanged.
+     * - `file://` URIs are passed through unchanged.
+     * - Absolute filesystem paths (`/…`) become `file://` URIs
+     *   (equivalent to `Uri.fromFile(File(path)).toString()`).
+     * - Anything else (e.g. already-resolved remote URL) is returned as-is.
+     */
+    fun toPlaybackUriString(rawUriOrPath: String): String {
+        val raw = rawUriOrPath.trim()
+        if (raw.startsWith("content://")) return raw
+        if (raw.startsWith("file://")) return raw
+        if (raw.startsWith("/")) return "file://$raw"
+        return raw
+    }
+
+    /** Playback URI string for a download record, or null if it has no location. */
+    fun localPlaybackUriString(downloaded: DownloadedTrackEntity): String? =
+        rawLocalUriString(downloaded)?.let(::toPlaybackUriString)
+
+    /**
+     * Sanitized `"artist - title"` base name, using the downloader's filename
+     * sanitization (pass `TrackDownloadManager::sanitizeDownloadFilename`).
+     */
+    fun publicDownloadBaseName(
+        title: String,
+        artist: String,
+        sanitize: (String) -> String,
+    ): String = sanitize("${artist.trim()} - ${title.trim()}")
+
+    /**
+     * Second-chance probe: finds a downloaded audio file directly in the
+     * public download directory, without consulting Room.
+     *
+     * @param musicDir the downloader's public music directory
+     *   (`Music/LastWave`).
+     * @param sanitize the downloader's filename sanitization.
+     * @param extensions playable audio extensions in probe order.
+     * @return the first non-empty match, or null when nothing valid exists.
+     */
+    fun findPublicDownloadFile(
+        musicDir: java.io.File,
+        title: String,
+        artist: String,
+        sanitize: (String) -> String,
+        extensions: List<String>,
+    ): java.io.File? {
+        if (!musicDir.isDirectory) return null
+        val base = publicDownloadBaseName(title, artist, sanitize)
+        return extensions.asSequence()
+            .map { java.io.File(musicDir, "$base.$it") }
+            .firstOrNull { it.isFile && it.length() > 0 }
+    }
+
+    /**
+     * Offline-first selection.
+     *
+     * @param findDownload DAO lookup: given the normalized [makeDownloadKey],
+     *   plus trimmed title/artist for the `findByTitleAndArtist` fallback,
+     *   returns the matching download record or null.
+     * @param localExists returns true when the record's local file is present
+     *   and readable (file `exists() && length() > 0`, or MediaStore stream
+     *   opens successfully).
+     * @param resolveRemote existing remote streaming/resolution logic; only
+     *   invoked when no *valid* local download exists.
+     * @param onStaleDownload invoked once when the DB has a record but the
+     *   file is gone, so the caller can reuse its existing stale-record
+     *   cleanup instead of duplicating it here.
+     * @param findStorageUri second-chance probe for a valid file on disk when
+     *   the Room lookup misses or is stale. Only when this also returns null
+     *   is [resolveRemote] invoked.
+     */
+    suspend fun selectPlaybackUri(
+        title: String,
+        artist: String,
+        findDownload: suspend (trackKey: String, title: String, artist: String) -> DownloadedTrackEntity?,
+        localExists: (DownloadedTrackEntity) -> Boolean,
+        resolveRemote: suspend () -> String,
+        onStaleDownload: suspend (DownloadedTrackEntity) -> Unit = {},
+        findStorageUri: (() -> String?)? = null,
+    ): String {
+        val cleanTitle = title.trim()
+        val cleanArtist = artist.trim()
+        if (cleanTitle.isBlank() || cleanArtist.isBlank()) {
+            return resolveRemote()
+        }
+        val downloaded = runCatching {
+            findDownload(makeDownloadKey(cleanTitle, cleanArtist), cleanTitle, cleanArtist)
+        }.getOrNull()
+
+        if (downloaded != null) {
+            if (runCatching { localExists(downloaded) }.getOrDefault(false)) {
+                localPlaybackUriString(downloaded)?.let { return it }
+            } else {
+                runCatching { onStaleDownload(downloaded) }
+            }
+        }
+        if (findStorageUri != null) {
+            runCatching { findStorageUri() }.getOrNull()?.let { return it }
+        }
+        return resolveRemote()
+    }
+}


### PR DESCRIPTION
Fixes #37.

Offline playback of already-downloaded files in Music/LastWave failed whenever the Room download record was missing (reinstall, cleared data) or stale, and on Android 13+ the app could not see those files at all:

- MusicPlayer now resolves Room first, then probes Music/LastWave through MediaStore.Audio ('artist - title'.ext) and plays the resulting content:// URI, keeping the legacy File probe as a last resort before remote streaming.
- Adds READ_MEDIA_AUDIO (Android 13+) to the manifest and requests it at startup; without it orphaned downloads are invisible to both File and MediaStore lookups (verified on Pixel 7 Pro).
- Extracts the pure offline-resolution decision table into OfflinePlaybackResolver (no Android deps, JVM-testable); downloader naming/key helpers shared via TrackDownloadManager.

Tested: fresh install on Pixel 7 Pro, granted audio permission, played an offline FLAC from Music/LastWave with network off.